### PR TITLE
🏷️ Version 1.0.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,3 +30,14 @@ body:
         - Auf einem Tablet
     validations:
       required: true
+  - type: dropdown
+    id: server
+    attributes:
+      label: Auf welchem Betriebssystem läuft deine MySpeed-Instanz?
+      multiple: true
+      options:
+        - Linux
+        - Windows
+        - macOS
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,3 +28,5 @@ body:
         - Im Browser
         - Auf dem Handy
         - Auf einem Tablet
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,30 @@
+name: 🐛 Fehler melden
+description: Melde einen Fehler oder Bug in MySpeed
+title: "[Fehler] "
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Allgemeines
+      description: Bitte bestätige, dass die Folgenden aussagen zutreffen
+      options:
+        - label: Ich habe auf die neuste Version von MySpeed aktualisiert.
+          required: true
+        - label: Mein Bug wurde noch nicht gemeldet
+          required: true
+  - type: textarea
+    attributes:
+      label: "Der Fehler"
+      description: "Beschreibe den Bug/Fehler genau ins Detail. Füge falls vorhanden auch Screenshots hinzu und gib an, wie man den Fehler reproduzieren kann"
+      placeholder: "Es erscheint ein Fehler bei ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Auf welchem Gerät rufst du die Seite auf?
+      multiple: true
+      options:
+        - Im Browser
+        - Auf dem Handy
+        - Auf einem Tablet

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: 💡 Idee vorschlagen
+description: Hast du eine Idee? Hier bist du richtig
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Allgemeines
+      description: Bitte bestätige, dass die Folgenden aussagen zutreffen
+      options:
+        - label: Mein Feature existiert noch nicht in der neusten Version von MySpeed.
+          required: true
+        - label: Ich habe überprüft, dass mein Feature noch von niemanden vorgeschlagen wurde.
+          required: true
+  - type: textarea
+    attributes:
+      label: "Deine Idee"
+      description: "Was können wir hinzufügen? Beschreibe deine Idee so genau wie möglich"
+      placeholder: "Meine Idee wäre es, ..."
+    validations:
+      required: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '16'
 
       - run: cd client && npm install
-      - run: npm run build && npm install
+      - run: npm run build && mv client/build . && npm install
 
       - name: Get version
         id: get_version

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -29,7 +29,10 @@ jobs:
         run: sudo apt-get install zip
 
       - name: Zip all files
-        run: zip -r MySpeed-${{ steps.get_version.outputs.version }}.zip build node_modules server package.json package-lock.json
+        run: zip -r MySpeed-${{ steps.get_version.outputs.version }}-with-modules.zip build node_modules server package.json package-lock.json
+
+      - name: Zip all files (without node_modules)
+        run: zip -r MySpeed-${{ steps.get_version.outputs.version }}-without-modules.zip build server package.json package-lock.json
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
@@ -38,4 +41,5 @@ jobs:
           prerelease: false
           title: Release ${{ steps.get_version.outputs.version }}
           files: |
-            ./MySpeed-*zip
+            ./MySpeed-*-with-modules.zip
+            ./MySpeed-*-without-modules.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # dependencies
 /node_modules
+/client/node_modules
 /.pnp
 .pnp.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # production
 /build
+/data

--- a/README.md
+++ b/README.md
@@ -12,40 +12,47 @@
 </p>
 <h3 align="center">MySpeed</h3>
 
-## Was ist das?
+## Was ist MySpeed?
 
-MySpeed ist eine deutschsprachige Speedtest Analyse-Software, welche das Internet der letzten 24 Stunden übersichtlich
+MySpeed ist eine deutschsprachige Speedtest Analyse-Software, welche die Geschwindigkeit des Internets der letzten 24 Stunden übersichtlich
 darstellt.
 
 ### Installation
 
-1. Stelle sicher, dass du nodejs installiert hast.
-2. Lade dir die neuste Version aus den [Releases](https://github.com/gnmyt/myspeed/releases/latest) herunter.
-3. Setze die Umgebungsvariable `NODE_ENV` auf `production`.
-4. Starte das Projekt. Das geht ganz einfach mit `node server`
+Anleitung für [Linux](https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux)
+
+Anleitung für [Windows](https://github.com/gnmyt/myspeed/wiki/Einrichtung-Windows)
 
 ### Beispiel-Screenshots
 
 #### Startseite
 
-<img src="https://i.imgur.com/vYWe5RJ.png">
+<img src="https://i.imgur.com/94rQ4jq.png">
 
 #### Auswahl-Menü
 
-<img src="https://i.imgur.com/vRhBYD2.png">
+<img src="https://i.imgur.com/tJHmUVs.png">
 
 #### Seite während eines Speedtests
 
-<img src="https://i.imgur.com/V7E3xH9.png">
+<img src="https://i.imgur.com/rqvb1Ni.png">
 
 #### Dialog für Einstellen des Down-Speeds
 
-<img src="https://i.imgur.com/Pxw42b8.png">
+<img src="https://i.imgur.com/DnEPbFV.png">
+
+### Geschützte Startseite (Passwort festgelegt)
+
+<img src="https://i.imgur.com/BGK166K.png">
+
+### Dialog für Up- und Downspeed Empfehlung
+
+<img src="https://i.imgur.com/ExgswYD.png">
+
 
 ## Überzeugt?
 
-Du kannst dir das Projekt ganz easy herunterladen und auf deinen Server Zuhause installieren. Gib mir gerne Feedback,
-falls ich etwas besser machen kann! :)
+Cool, dann lass und loslegen! Die Installationsanleitung für Linux (und Windows) findest du oben unter Installation.
 
 ## Lizenz
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Anleitung für [Windows](https://github.com/gnmyt/myspeed/wiki/Einrichtung-Windo
 
 ## Überzeugt?
 
-Cool, dann lass und loslegen! Die Installationsanleitung für Linux (und Windows) findest du oben unter Installation.
+Cool, dann lass uns loslegen! Die Installationsanleitung für Linux (und Windows) findest du oben unter Installation.
 
 ## Lizenz
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,26 +4,29 @@ import HeaderComponent from "./components/HeaderComponent";
 import TestAreaComponent from "./components/TestAreaComponent";
 import {ConfigProvider} from "./context/ConfigContext";
 import {DialogProvider} from "./context/DialogContext";
+import {SpeedtestProvider} from "./context/SpeedtestContext";
 
 function App() {
 
     return (
-        <div className="App">
-            <DialogProvider>
-                <ConfigProvider>
-                <HeaderComponent/>
-                <main>
+        <>
+            <SpeedtestProvider>
+                <DialogProvider>
+                    <ConfigProvider>
 
-                    <LatestTestComponent/>
+                        <HeaderComponent/>
+                        <main>
+                            <LatestTestComponent/>
 
-                    <hr/>
+                            <hr/>
 
-                    <TestAreaComponent/>
+                            <TestAreaComponent/>
+                        </main>
 
-                </main>
-            </ConfigProvider>
-            </DialogProvider>
-        </div>
+                    </ConfigProvider>
+                </DialogProvider>
+            </SpeedtestProvider>
+        </>
     );
 }
 

--- a/client/src/App.sass
+++ b/client/src/App.sass
@@ -20,6 +20,8 @@ body, html
   margin-right: 10px
 
 .container-icon
+  width: 35px
+  height: 35px
   color: #F1F1F1
   font-size: 26pt
 

--- a/client/src/App.sass
+++ b/client/src/App.sass
@@ -31,6 +31,9 @@ body, html
 .icon-red
   color: #C64545
 
+.icon-white
+  color: #ffffff
+
 .icon-error
   color: #900c0c
 

--- a/client/src/HelperFunctions.js
+++ b/client/src/HelperFunctions.js
@@ -20,7 +20,7 @@ export function generateRelativeTime(created) {
 export function getIconBySpeed(current, optional, higherIsBetter) {
     let speed = Math.floor((current / optional) * 100);
 
-    if (current === 0) return "error";
+    if (current === -1) return "error";
 
     if (higherIsBetter) {
         if (speed >= 75) return "green";

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -3,7 +3,7 @@ import "../style/Dropdown.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {
     faArrowDown,
-    faArrowUp, faClose, faFileExport,
+    faArrowUp, faClock, faClose, faFileExport,
     faGear, faInfo,
     faKey,
     faPause,
@@ -259,6 +259,27 @@ function DropdownComponent() {
         });
     }
 
+    const updateLevel = async () => {
+        toggleDropdown();
+        fetch("/api/config/timeLevel", {headers: headers}).then(res => res.json())
+            .then(level => setDialog({
+                title: "Test-Häufigkeit einstellen",
+                select: true,
+                selectOptions: {
+                    1: "Durchgehend (jede Minute)",
+                    2: "Sehr häufig (alle 30 Minuten)",
+                    3: "Häufig (jede Stunde)",
+                    4: "Selten (alle 3 Stunden)",
+                    5: "Sehr selten (alle 6 Stunden)"
+                },
+                value: level.value,
+                onSuccess: value => {
+                    fetch("/api/config/timeLevel", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
+                        .then(() => showFeedback());
+                }
+            }));
+    }
+
     return (
         <div className="dropdown dropdown-invisible">
             <div id="dropdown" className="dropdown-content">
@@ -290,6 +311,10 @@ function DropdownComponent() {
                     <div className="dropdown-item" onClick={updatePassword}>
                         <FontAwesomeIcon icon={faKey}/>
                         <h3>Passwort ändern</h3>
+                    </div>
+                    <div className="dropdown-item" onClick={updateLevel}>
+                        <FontAwesomeIcon icon={faClock}/>
+                        <h3>Häufigkeit einstellen</h3>
                     </div>
                     <div className="dropdown-item" onClick={exportDialog}>
                         <FontAwesomeIcon icon={faFileExport}/>

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -130,13 +130,20 @@ function DropdownComponent() {
         })
     }
 
-    const updateServer = async () => {
+    const updateServer = () => {
         toggleDropdown();
+
+        let servers = {};
+        fetch("/api/info/server", {headers: headers})
+            .then(res => res.json())
+            .then(json => servers = json);
+
         fetch("/api/config/serverId", {headers: headers}).then(res => res.json())
-            .then(ping => setDialog({
+            .then(async server => setDialog({
                 title: "Speedtest-Server setzen",
-                placeholder: "Server-ID",
-                value: ping.value,
+                select: true,
+                selectOptions: servers,
+                value: server.value,
                 onSuccess: value => {
                     fetch("/api/config/serverId", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
                         .then(() => showFeedback());

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -208,13 +208,25 @@ function DropdownComponent() {
         setDialog({
             select: true,
             title: "Speedtests exportieren",
+            buttonText: "Herunterladen",
             value: "json",
             selectOptions: {
                 json: "JSON-Datei",
                 csv: "CSV-Datei"
             },
             onSuccess: value => {
-                window.location.href = "/api/export/" + value;
+                fetch("/api/export/" + value, {headers: headers})
+                    .then(async res => {
+                        let element = document.createElement('a');
+                        let url = res.headers.get('Content-Disposition').split('filename=')[1];
+                        element.setAttribute("download", url.replaceAll("\"", ""));
+                        res.blob().then(async blob => {
+                            element.href = window.URL.createObjectURL(blob);
+                            document.body.appendChild(element);
+                            element.click();
+                            element.remove();
+                        });
+                    });
             }
         });
     }

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -143,6 +143,9 @@ function DropdownComponent() {
                     select: true,
                     selectOptions: servers,
                     value: server.value,
+                    unsetButton: true,
+                    unsetButtonText: "Manuell festlegen",
+                    onClear: () => updateServerManually(),
                     onSuccess: value => {
                         fetch("/api/config/serverId", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
                             .then(() => showFeedback());
@@ -150,6 +153,19 @@ function DropdownComponent() {
                 })));
     }
 
+    const updateServerManually = () => {
+        fetch("/api/config/serverId", {headers: headers}).then(res => res.json())
+            .then(async server => setDialog({
+                title: "Speedtest-Server setzen",
+                placeholder: "Server-ID",
+                type: "number",
+                value: server.value,
+                onSuccess: value => {
+                    fetch("/api/config/serverId", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
+                        .then(() => showFeedback());
+                }
+            }))
+    }
 
     function togglePause() {
         toggleDropdown();

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -136,19 +136,18 @@ function DropdownComponent() {
         let servers = {};
         fetch("/api/info/server", {headers: headers})
             .then(res => res.json())
-            .then(json => servers = json);
-
-        fetch("/api/config/serverId", {headers: headers}).then(res => res.json())
-            .then(async server => setDialog({
-                title: "Speedtest-Server setzen",
-                select: true,
-                selectOptions: servers,
-                value: server.value,
-                onSuccess: value => {
-                    fetch("/api/config/serverId", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
-                        .then(() => showFeedback());
-                }
-            }));
+            .then(json => servers = json)
+            .then(() => fetch("/api/config/serverId", {headers: headers}).then(res => res.json())
+                .then(async server => setDialog({
+                    title: "Speedtest-Server setzen",
+                    select: true,
+                    selectOptions: servers,
+                    value: server.value,
+                    onSuccess: value => {
+                        fetch("/api/config/serverId", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
+                            .then(() => showFeedback());
+                    }
+                })));
     }
 
 

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -3,7 +3,7 @@ import "../style/Dropdown.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {
     faArrowDown,
-    faArrowUp, faClose,
+    faArrowUp, faClose, faFileExport,
     faGear, faInfo,
     faKey,
     faPause,
@@ -51,14 +51,15 @@ function DropdownComponent() {
 
 
     function setPause(paused) {
-        let element = document.getElementsByClassName("analyse-area")[0].classList;
+        let element = document.getElementsByClassName("analyse-area")[0];
+        if (element == null) return;
 
         if (paused) {
-            if (!element.contains("tests-paused")) element.add("tests-paused");
+            if (!element.classList.contains("tests-paused")) element.classList.add("tests-paused");
         } else {
-            if (element.contains("tests-paused")) element.remove("tests-paused");
+            if (element.classList.contains("tests-paused")) element.classList.remove("tests-paused");
         }
-        
+
        setPauseState(paused);
     }
 
@@ -67,7 +68,7 @@ function DropdownComponent() {
             .then(res => res.json())
             .then(res => setPause(res.paused));
     }
-    
+
     useEffect(() => {
         const interval = setInterval(() => checkPauseStatus(), 15000);
         checkPauseStatus();
@@ -202,6 +203,22 @@ function DropdownComponent() {
             }));
     }
 
+    function exportDialog() {
+        toggleDropdown();
+        setDialog({
+            select: true,
+            title: "Speedtests exportieren",
+            value: "json",
+            selectOptions: {
+                json: "JSON-Datei",
+                csv: "CSV-Datei"
+            },
+            onSuccess: value => {
+                window.location.href = "/api/export/" + value;
+            }
+        });
+    }
+
     return (
         <div className="dropdown dropdown-invisible">
             <div id="dropdown" className="dropdown-content">
@@ -233,6 +250,10 @@ function DropdownComponent() {
                     <div className="dropdown-item" onClick={updatePassword}>
                         <FontAwesomeIcon icon={faKey}/>
                         <h3>Passwort ändern</h3>
+                    </div>
+                    <div className="dropdown-item" onClick={exportDialog}>
+                        <FontAwesomeIcon icon={faFileExport}/>
+                        <h3>Tests exportieren</h3>
                     </div>
                     <div className="dropdown-item" onClick={togglePause}>
                     <FontAwesomeIcon icon={pauseState ? faPlay : faPause}/>

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -55,9 +55,15 @@ function DropdownComponent() {
         if (element == null) return;
 
         if (paused) {
-            if (!element.classList.contains("tests-paused")) element.classList.add("tests-paused");
+            if (!element.classList.contains("tests-paused")) {
+                element.classList.add("tests-paused");
+                element.classList.remove("pulse");
+            }
         } else {
-            if (element.classList.contains("tests-paused")) element.classList.remove("tests-paused");
+            if (element.classList.contains("tests-paused")) {
+                element.classList.remove("tests-paused");
+                element.classList.add("pulse");
+            }
         }
 
        setPauseState(paused);

--- a/client/src/components/DropdownComponent.js
+++ b/client/src/components/DropdownComponent.js
@@ -79,6 +79,8 @@ function DropdownComponent() {
         const interval = setInterval(() => checkPauseStatus(), 15000);
         checkPauseStatus();
         return () => clearInterval(interval);
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const updateDownload = async () => {

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -3,7 +3,7 @@ import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faCircleExclamation, faGaugeHigh, faGear} from "@fortawesome/free-solid-svg-icons";
 import DropdownComponent, {toggleDropdown} from "./DropdownComponent";
 import {useContext, useEffect, useState} from "react";
-import { DialogContext } from "../context/DialogContext";
+import {DialogContext} from "../context/DialogContext";
 
 
 function HeaderComponent() {
@@ -12,49 +12,56 @@ function HeaderComponent() {
     const [icon, setIcon] = useState(faGear);
     const [updateAvailable, setUpdateAvailable] = useState("");
 
-    let headers = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
+    const headers = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
     headers['content-type'] = 'application/json'
-    
+
     function switchDropdown() {
         toggleDropdown(setIcon);
     }
 
     const startSpeedtest = async () => {
-        setDialog({speedtest: true, promise: fetch("/api/speedtests/run", {headers: headers, method: "POST"})});
-    }
-
-    function checkUpdate() {
-        fetch("/api/info/version", {headers: headers})
-            .then(res => res.json())
-            .then(version => {
-                if (version.remote.localeCompare(version.local, undefined, 
-                    {numeric: true, sensitivity: 'base'}) === 1) {
-                        setUpdateAvailable(version.remote);
-                }
-            });
+        setDialog({speedtest: true, promise: fetch("/api/speedtests/run", {headers, method: "POST"})});
     }
 
     useEffect(() => {
-        checkUpdate();
-    });
+        fetch("/api/info/version", {headers})
+            .then(res => res.json())
+            .then(version => {
+                if (version.remote.localeCompare(version.local, undefined,
+                    {numeric: true, sensitivity: 'base'}) === 1)
+                    setUpdateAvailable(version.remote);
+            });
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <header>
             <div className="header-main">
                 <h2>Netzwerkanalyse</h2>
                 <div className="header-right">
-                    {updateAvailable ? <FontAwesomeIcon icon={faCircleExclamation} className="header-icon icon-orange" 
-                    onClick={() => setDialog({title: "Update verfügbar", buttonText: "Okay", description: <>Ein Update auf die Version {updateAvailable} ist verfügbar.
-                        Sieh dir <a target="_blank" href="https://github.com/gnmyt/myspeed/releases/latest" rel="noreferrer">die Änderungen an</a> und <a target="_blank" 
-                        href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux" rel="noreferrer">lade dir das Update herunter</a>.</>})} /> 
+                    {updateAvailable ?
+                        <div><FontAwesomeIcon icon={faCircleExclamation} className="header-icon icon-orange"
+                                              onClick={() => setDialog({
+                                                  title: "Update verfügbar",
+                                                  buttonText: "Okay",
+                                                  description: <>Ein Update auf die Version {updateAvailable} ist
+                                                      verfügbar. Sieh dir <a target="_blank"
+                                                                             href="https://github.com/gnmyt/myspeed/releases/latest"
+                                                                             rel="noreferrer">die Änderungen
+                                                          an</a> und <a target="_blank"
+                                                                        href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux"
+                                                                        rel="noreferrer">lade dir das Update
+                                                          herunter</a>.</>
+                                              })}/></div>
                         : <></>}
                     <div className="tooltip-element tooltip-bottom">
-                        <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
+                        <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest}/>
                         <span className="tooltip">Speedtest starten</span>
                     </div>
 
                     <div className="tooltip-element tooltip-bottom">
-                        <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />
+                        <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown}/>
                         <span className="tooltip">Einstellungen</span>
                     </div>
 

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -48,8 +48,16 @@ function HeaderComponent() {
                         Sieh dir <a target="_blank" href="https://github.com/gnmyt/myspeed/releases/latest" rel="noreferrer">die Änderungen an</a> und <a target="_blank" 
                         href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux" rel="noreferrer">lade dir das Update herunter</a>.</>})} /> 
                         : <></>}
-                    <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
-                    <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />
+                    <div className="tooltip-element tooltip-bottom">
+                        <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
+                        <span className="tooltip">Test starten</span>
+                    </div>
+
+                    <div className="tooltip-element tooltip-bottom">
+                        <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />
+                        <span className="tooltip">Einstellungen</span>
+                    </div>
+
                 </div>
             </div>
             <DropdownComponent/>

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -1,22 +1,35 @@
 import "../style/Header.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faGear} from "@fortawesome/free-solid-svg-icons";
+import {faGaugeHigh, faGear} from "@fortawesome/free-solid-svg-icons";
 import DropdownComponent, {toggleDropdown} from "./DropdownComponent";
-import {useState} from "react";
+import {useContext, useState} from "react";
+import { DialogContext } from "../context/DialogContext";
+
 
 function HeaderComponent() {
 
+    const [setDialog] = useContext(DialogContext);
     const [icon, setIcon] = useState(faGear);
 
+    let headers = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
+    headers['content-type'] = 'application/json'
+    
     function switchDropdown() {
         toggleDropdown(setIcon);
+    }
+
+    const startSpeedtest = async () => {
+        setDialog({speedtest: true, promise: fetch("/api/speedtests/run", {headers: headers, method: "POST"})});
     }
 
     return (
         <header>
             <div className="header-main">
                 <h2>Netzwerkanalyse</h2>
-                <FontAwesomeIcon icon={icon} className="settings" onClick={switchDropdown}/>
+                <div className="header-right">
+                    <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
+                    <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />
+                </div>
             </div>
             <DropdownComponent/>
         </header>

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -50,7 +50,7 @@ function HeaderComponent() {
                         : <></>}
                     <div className="tooltip-element tooltip-bottom">
                         <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
-                        <span className="tooltip">Test starten</span>
+                        <span className="tooltip">Speedtest starten</span>
                     </div>
 
                     <div className="tooltip-element tooltip-bottom">

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -1,8 +1,8 @@
 import "../style/Header.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faGaugeHigh, faGear} from "@fortawesome/free-solid-svg-icons";
+import {faCircleExclamation, faGaugeHigh, faGear} from "@fortawesome/free-solid-svg-icons";
 import DropdownComponent, {toggleDropdown} from "./DropdownComponent";
-import {useContext, useState} from "react";
+import {useContext, useEffect, useState} from "react";
 import { DialogContext } from "../context/DialogContext";
 
 
@@ -10,6 +10,7 @@ function HeaderComponent() {
 
     const [setDialog] = useContext(DialogContext);
     const [icon, setIcon] = useState(faGear);
+    const [updateAvailable, setUpdateAvailable] = useState("");
 
     let headers = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
     headers['content-type'] = 'application/json'
@@ -22,11 +23,31 @@ function HeaderComponent() {
         setDialog({speedtest: true, promise: fetch("/api/speedtests/run", {headers: headers, method: "POST"})});
     }
 
+    function checkUpdate() {
+        fetch("/api/info/version", {headers: headers})
+            .then(res => res.json())
+            .then(version => {
+                if (version.remote.localeCompare(version.local, undefined, 
+                    {numeric: true, sensitivity: 'base'}) === 1) {
+                        setUpdateAvailable(version.remote);
+                }
+            });
+    }
+
+    useEffect(() => {
+        checkUpdate();
+    });
+
     return (
         <header>
             <div className="header-main">
                 <h2>Netzwerkanalyse</h2>
                 <div className="header-right">
+                    {updateAvailable ? <FontAwesomeIcon icon={faCircleExclamation} className="header-icon icon-orange" 
+                    onClick={() => setDialog({title: "Update verfügbar", buttonText: "Okay", description: <p>Ein Update auf die Version {updateAvailable} ist verfügbar.
+                        Sieh dir <a target="_blank" href="https://github.com/gnmyt/myspeed/releases/latest" rel="noreferrer">die Änderungen an</a> und <a target="_blank" 
+                        href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux" rel="noreferrer">lade dir das Update herunter</a>.</p>})} /> 
+                        : <></>}
                     <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
                     <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />
                 </div>

--- a/client/src/components/HeaderComponent.js
+++ b/client/src/components/HeaderComponent.js
@@ -44,9 +44,9 @@ function HeaderComponent() {
                 <h2>Netzwerkanalyse</h2>
                 <div className="header-right">
                     {updateAvailable ? <FontAwesomeIcon icon={faCircleExclamation} className="header-icon icon-orange" 
-                    onClick={() => setDialog({title: "Update verfügbar", buttonText: "Okay", description: <p>Ein Update auf die Version {updateAvailable} ist verfügbar.
+                    onClick={() => setDialog({title: "Update verfügbar", buttonText: "Okay", description: <>Ein Update auf die Version {updateAvailable} ist verfügbar.
                         Sieh dir <a target="_blank" href="https://github.com/gnmyt/myspeed/releases/latest" rel="noreferrer">die Änderungen an</a> und <a target="_blank" 
-                        href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux" rel="noreferrer">lade dir das Update herunter</a>.</p>})} /> 
+                        href="https://github.com/gnmyt/myspeed/wiki/Einrichtung-Linux" rel="noreferrer">lade dir das Update herunter</a>.</>})} /> 
                         : <></>}
                     <FontAwesomeIcon icon={faGaugeHigh} className="header-icon" onClick={startSpeedtest} />
                     <FontAwesomeIcon icon={icon} className="header-icon" onClick={switchDropdown} />

--- a/client/src/components/LatestTestComponent.js
+++ b/client/src/components/LatestTestComponent.js
@@ -46,7 +46,7 @@ function LatestTestComponent() {
                     <h2 className="container-text">Ping<span className="container-subtext">ms</span></h2>
                 </div>
                 <div className="container-main">
-                    <h2>{latest.ping === 0 ? "Test" : latest.ping}</h2>
+                    <h2>{latest.ping === -1 ? "Test" : latest.ping}</h2>
                 </div>
             </div>
 
@@ -61,7 +61,7 @@ function LatestTestComponent() {
                     <h2 className="container-text">Download<span className="container-subtext">Mbit/s</span></h2>
                 </div>
                 <div className="container-main">
-                    <h2>{latest.download === 0 ? "schlug" : latest.download}</h2>
+                    <h2>{latest.download === -1 ? "schlug" : latest.download}</h2>
                 </div>
             </div>
 
@@ -76,7 +76,7 @@ function LatestTestComponent() {
                     <h2 className="container-text">Upload<span className="container-subtext">Mbit/s</span></h2>
                 </div>
                 <div className="container-main">
-                    <h2>{latest.upload === 0 ? "fehl!" : latest.upload}</h2>
+                    <h2>{latest.upload === -1 ? "fehl!" : latest.upload}</h2>
                 </div>
             </div>
 

--- a/client/src/components/LatestTestComponent.js
+++ b/client/src/components/LatestTestComponent.js
@@ -36,7 +36,7 @@ function LatestTestComponent() {
     if (Object.entries(config).length === 0) return (<></>)
 
     return (
-        <div className="analyse-area">
+        <div className="analyse-area pulse">
             {/* Ping */}
             <div className="inner-container">
                 <div className="container-header">

--- a/client/src/components/LatestTestComponent.js
+++ b/client/src/components/LatestTestComponent.js
@@ -5,35 +5,26 @@ import {generateRelativeTime, getIconBySpeed} from "../HelperFunctions";
 import {useContext, useEffect, useState} from "react";
 import {ConfigContext} from "../context/ConfigContext";
 import {DialogContext} from "../context/DialogContext";
+import {SpeedtestContext} from "../context/SpeedtestContext";
 
 function LatestTestComponent() {
-    const [latest, setLatest] = useState({});
-    const [latestTestTime, setLatestTestTime] = useState("");
+    const [latest, setLatest] = useState({ping: "-", download: "-", upload: "-"});
+    const [latestTestTime, setLatestTestTime] = useState("-");
     const [setDialog] = useContext(DialogContext);
+    const [speedtests] = useContext(SpeedtestContext);
     const config = useContext(ConfigContext);
 
-    function updateTest() {
-        let passwordHeaders = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
-        fetch("/api/speedtests/latest", {headers: passwordHeaders})
-            .then(res => res.json())
-            .then(latest => {
-                setLatest(latest);
-                setLatestTestTime(generateRelativeTime(latest.created));
-            });
-    }
+    useEffect(() => setLatest(speedtests[0]), [speedtests]);
 
     useEffect(() => {
-        const interval = setInterval(() => updateTest(), 15000);
-        updateTest();
-        return () => clearInterval(interval);
-    }, [setLatest]);
-
-    useEffect(() => {
+        if (latest) setLatestTestTime(generateRelativeTime(latest.created));
         const interval = setInterval(() => setLatestTestTime(generateRelativeTime(latest.created)), 1000);
         return () => clearInterval(interval);
-    }, [setLatestTestTime, latest]);
+    }, [latest]);
 
-    if (Object.entries(config).length === 0) return (<></>)
+    if (!latest) return <></>;
+
+    if (Object.entries(config).length === 0) return (<></>);
 
     return (
         <div className="analyse-area pulse">

--- a/client/src/components/SpeedtestComponent.js
+++ b/client/src/components/SpeedtestComponent.js
@@ -21,15 +21,15 @@ class Speedtest extends Component {
                     </div>
                     <div className="speedtest-row">
                         <FontAwesomeIcon icon={this.props.ping !== 0 ? faPingPongPaddleBall : faClose} className={"speedtest-icon icon-" + this.props.pingLevel}/>
-                        <h2 className="speedtest-text">{this.props.ping === 0 ? "" : this.props.ping}</h2>
+                        <h2 className="speedtest-text">{this.props.ping === -1 ? "" : this.props.ping}</h2>
                     </div>
                     <div className="speedtest-row">
                         <FontAwesomeIcon icon={this.props.down !== 0 ? faArrowDown : faClose} className={"speedtest-icon icon-" + this.props.downLevel} />
-                        <h2 className="speedtest-text">{this.props.down === 0 ? "" : this.props.down}</h2>
+                        <h2 className="speedtest-text">{this.props.down === -1 ? "" : this.props.down}</h2>
                     </div>
                     <div className="speedtest-row">
                         <FontAwesomeIcon icon={this.props.up !== 0 ? faArrowUp : faClose} className={"speedtest-icon icon-" + this.props.upLevel}/>
-                        <h2 className="speedtest-text">{this.props.up === 0 ? "" : this.props.up}</h2>
+                        <h2 className="speedtest-text">{this.props.up === -1 ? "" : this.props.up}</h2>
                     </div>
                 </div>
             </div>

--- a/client/src/components/SpeedtestComponent.js
+++ b/client/src/components/SpeedtestComponent.js
@@ -9,10 +9,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import "../style/Speedtest.sass";
 import {DialogContext} from "../context/DialogContext";
+import {SpeedtestContext} from "../context/SpeedtestContext";
 
 function SpeedtestComponent(props) {
 
     const [setDialog] = useContext(DialogContext);
+    const updateTests = useContext(SpeedtestContext)[1];
 
     let passwordHeaders = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
 
@@ -31,7 +33,7 @@ function SpeedtestComponent(props) {
                                              unsetButton: true,
                                              unsetButtonText: "Test löschen",
                                              onClear: () => fetch("/api/speedtests/"+props.id, {headers: passwordHeaders, method: "DELETE"})
-                                                 .then(() => window.location.reload())
+                                                 .then(updateTests)
                                          }) : () => setDialog({
                                              title: "Testergebnis",
                                              description: <>Dieser Test erreichte eine maximale Downloadgeschwindigkeit von <span className="dialog-value">{props.down} Mbit/s </span>
@@ -41,7 +43,7 @@ function SpeedtestComponent(props) {
                                              unsetButton: true,
                                              unsetButtonText: "Test löschen",
                                              onClear: () => fetch("/api/speedtests/"+props.id, {headers: passwordHeaders, method: "DELETE"})
-                                                 .then(() => window.location.reload())
+                                                 .then(updateTests)
                                          })} />
                         <span className="tooltip">{props.type === "custom" ? "Benutzerdefiniert" :"Automatisiert"}</span>
                     </div>

--- a/client/src/components/SpeedtestComponent.js
+++ b/client/src/components/SpeedtestComponent.js
@@ -14,6 +14,8 @@ function SpeedtestComponent(props) {
 
     const [setDialog] = useContext(DialogContext);
 
+    let passwordHeaders = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
+
     return (
         <div>
             <div className="speedtest">
@@ -25,13 +27,21 @@ function SpeedtestComponent(props) {
                                              title: "Test fehlgeschlagen",
                                              description: props.error.includes("Network unreachable") ? "Die Internetverbindung scheint unterbrochen gewesen zu sein. " +
                                                  "Bitte überprüfe weitestgehend, ob das öfters passiert." : "Unbekannter Fehler: " + props.error,
-                                             buttonText: "Okay"
+                                             buttonText: "Okay",
+                                             unsetButton: true,
+                                             unsetButtonText: "Test löschen",
+                                             onClear: () => fetch("/api/speedtests/"+props.id, {headers: passwordHeaders, method: "DELETE"})
+                                                 .then(() => window.location.reload())
                                          }) : () => setDialog({
                                              title: "Testergebnis",
                                              description: <>Dieser Test erreichte eine maximale Downloadgeschwindigkeit von <span className="dialog-value">{props.down} Mbit/s </span>
                                                     und eine maximale Uploadgeschwindigkeit von <span className="dialog-value">{props.up} Mbit/s</span>. Er wurde <span className="dialog-value">{props.type === "custom"
                                                      ? "von dir" : "automatisch"}</span> angelegt und hat <span className="dialog-value">{props.duration} Sekunden</span> gedauert.</>,
-                                             buttonText: "Okay"
+                                             buttonText: "Okay",
+                                             unsetButton: true,
+                                             unsetButtonText: "Test löschen",
+                                             onClear: () => fetch("/api/speedtests/"+props.id, {headers: passwordHeaders, method: "DELETE"})
+                                                 .then(() => window.location.reload())
                                          })} />
                         <span className="tooltip">{props.type === "custom" ? "Benutzerdefiniert" :"Automatisiert"}</span>
                     </div>

--- a/client/src/components/SpeedtestComponent.js
+++ b/client/src/components/SpeedtestComponent.js
@@ -1,40 +1,61 @@
-import {Component} from "react";
+import React, {useContext} from "react";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {
     faArrowDown,
     faArrowUp,
     faClockRotateLeft,
-    faClose,
+    faClose, faInfo,
     faPingPongPaddleBall
 } from "@fortawesome/free-solid-svg-icons";
 import "../style/Speedtest.sass";
+import {DialogContext} from "../context/DialogContext";
 
-class Speedtest extends Component {
+function SpeedtestComponent(props) {
 
-    render() {
-        return (
-            <div>
-                <div className="speedtest">
-                    <div className="date">
-                        <FontAwesomeIcon icon={faClockRotateLeft} className="container-icon icon-blue"/>
-                        <h2 className="date-text">Um {this.props.time}</h2>
+    const [setDialog] = useContext(DialogContext);
+
+    return (
+        <div>
+            <div className="speedtest">
+                <div className="date">
+                    <div className="tooltip-element">
+                        <FontAwesomeIcon icon={props.error ? faInfo : faClockRotateLeft}
+                                         className={"container-icon help-icon icon-" + (props.error ? "error" : "blue")}
+                                         onClick={props.error ? () => setDialog({
+                                             title: "Test fehlgeschlagen",
+                                             description: props.error.includes("Network unreachable") ? "Die Internetverbindung scheint unterbrochen gewesen zu sein. " +
+                                                 "Bitte überprüfe weitestgehend, ob das öfters passiert." : "Unbekannter Fehler: " + props.error,
+                                             buttonText: "Okay"
+                                         }) : () => setDialog({
+                                             title: "Testergebnis",
+                                             description: <>Dieser Test erreichte eine maximale Downloadgeschwindigkeit von <span className="dialog-value">{props.down} Mbit/s </span>
+                                                    und eine maximale Uploadgeschwindigkeit von <span className="dialog-value">{props.up} Mbit/s</span>. Er wurde <span className="dialog-value">{props.type === "custom"
+                                                     ? "von dir" : "automatisch"}</span> angelegt und hat <span className="dialog-value">{props.duration} Sekunden</span> gedauert.</>,
+                                             buttonText: "Okay"
+                                         })} />
+                        <span className="tooltip">{props.type === "custom" ? "Benutzerdefiniert" :"Automatisiert"}</span>
                     </div>
-                    <div className="speedtest-row">
-                        <FontAwesomeIcon icon={this.props.ping !== 0 ? faPingPongPaddleBall : faClose} className={"speedtest-icon icon-" + this.props.pingLevel}/>
-                        <h2 className="speedtest-text">{this.props.ping === -1 ? "" : this.props.ping}</h2>
-                    </div>
-                    <div className="speedtest-row">
-                        <FontAwesomeIcon icon={this.props.down !== 0 ? faArrowDown : faClose} className={"speedtest-icon icon-" + this.props.downLevel} />
-                        <h2 className="speedtest-text">{this.props.down === -1 ? "" : this.props.down}</h2>
-                    </div>
-                    <div className="speedtest-row">
-                        <FontAwesomeIcon icon={this.props.up !== 0 ? faArrowUp : faClose} className={"speedtest-icon icon-" + this.props.upLevel}/>
-                        <h2 className="speedtest-text">{this.props.up === -1 ? "" : this.props.up}</h2>
-                    </div>
+
+                    <h2 className="date-text">Um {props.time}</h2>
+                </div>
+                <div className="speedtest-row">
+                    <FontAwesomeIcon icon={props.error ? faClose : faPingPongPaddleBall}
+                                     className={"speedtest-icon icon-" + props.pingLevel}/>
+                    <h2 className="speedtest-text">{props.error ? "" : props.ping}</h2>
+                </div>
+                <div className="speedtest-row">
+                    <FontAwesomeIcon icon={props.error ? faClose : faArrowDown}
+                                     className={"speedtest-icon icon-" + props.downLevel}/>
+                    <h2 className="speedtest-text">{props.error ? "" : props.down}</h2>
+                </div>
+                <div className="speedtest-row">
+                    <FontAwesomeIcon icon={props.error ? faClose : faArrowUp}
+                                     className={"speedtest-icon icon-" + props.upLevel}/>
+                    <h2 className="speedtest-text">{props.error ? "" : props.up}</h2>
                 </div>
             </div>
-        );
-    }
+        </div>
+    );
 }
 
-export default Speedtest;
+export default SpeedtestComponent;

--- a/client/src/components/TestAreaComponent.js
+++ b/client/src/components/TestAreaComponent.js
@@ -37,6 +37,7 @@ function TestArea() {
                                       url={test.url}
                                       type={test.type}
                                       duration={test.time}
+                                      id={test.id}
                     />
                 }) : ""}
             </div>

--- a/client/src/components/TestAreaComponent.js
+++ b/client/src/components/TestAreaComponent.js
@@ -30,10 +30,12 @@ function TestArea() {
                     let timeString = String(date.getHours()).padStart(2, '0') + ":" + String(date.getMinutes()).padStart(2, '0');
                     return <Speedtest time={timeString}
                                       ping={test.ping} pingLevel={getIconBySpeed(test.ping, config.ping, false)}
-                                      down={test.download}
-                                      downLevel={getIconBySpeed(test.download, config.download, true)}
+                                      down={test.download} downLevel={getIconBySpeed(test.download, config.download, true)}
                                       up={test.upload} upLevel={getIconBySpeed(test.upload, config.upload, true)}
+                                      error={test.error}
                                       key={test.id}
+                                      url={test.url}
+                                      duration={test.time}
                     />
                 }) : ""}
             </div>

--- a/client/src/components/TestAreaComponent.js
+++ b/client/src/components/TestAreaComponent.js
@@ -1,31 +1,19 @@
-import {useContext, useEffect, useState} from "react";
+import {useContext} from "react";
 import Speedtest from "./SpeedtestComponent";
 import {getIconBySpeed} from "../HelperFunctions";
 import {ConfigContext} from "../context/ConfigContext";
+import {SpeedtestContext} from "../context/SpeedtestContext";
 
 function TestArea() {
     const config = useContext(ConfigContext);
-    const [tests, setTests] = useState([]);
-
-    function updateTests() {
-        let passwordHeaders = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
-        fetch("/api/speedtests", {headers: passwordHeaders})
-            .then(res => res.json())
-            .then(tests => setTests(tests))
-    }
-
-    useEffect(() => {
-        const interval = setInterval(() => updateTests(), 15000);
-        updateTests();
-        return () => clearInterval(interval);
-    }, [setTests]);
+    const [speedtests] = useContext(SpeedtestContext);
 
     if (Object.entries(config).length === 0) return (<></>)
 
     return (
         <div className="individual-area">
             <div className="speedtests">
-                {tests.map ? tests.map(test => {
+                {speedtests.map ? speedtests.map(test => {
                     let date = new Date(Date.parse(test.created));
                     let timeString = String(date.getHours()).padStart(2, '0') + ":" + String(date.getMinutes()).padStart(2, '0');
                     return <Speedtest time={timeString}

--- a/client/src/components/TestAreaComponent.js
+++ b/client/src/components/TestAreaComponent.js
@@ -35,6 +35,7 @@ function TestArea() {
                                       error={test.error}
                                       key={test.id}
                                       url={test.url}
+                                      type={test.type}
                                       duration={test.time}
                     />
                 }) : ""}

--- a/client/src/context/ConfigContext.js
+++ b/client/src/context/ConfigContext.js
@@ -30,7 +30,7 @@ export const ConfigProvider = (props) => {
                     window.location.reload();
                 }
             }));
-    }, []);
+    }, [setDialog]);
 
     return (
         <ConfigContext.Provider value={config}>

--- a/client/src/context/ConfigContext.js
+++ b/client/src/context/ConfigContext.js
@@ -30,7 +30,7 @@ export const ConfigProvider = (props) => {
                     window.location.reload();
                 }
             }));
-    }, [setConfig, setDialog]);
+    }, []);
 
     return (
         <ConfigContext.Provider value={config}>

--- a/client/src/context/ConfigContext.js
+++ b/client/src/context/ConfigContext.js
@@ -22,7 +22,7 @@ export const ConfigProvider = (props) => {
                 title: "Passwort erforderlich",
                 placeholder: "Dein Passwort",
                 description: localStorage.getItem("password") ? <span className="icon-red">Das von dir eingegebene Passwort ist falsch</span> : "",
-                password: true,
+                type: "password",
                 buttonText: "Fertig",
                 onClose: () => window.location.reload(),
                 onSuccess: (value) => {

--- a/client/src/context/DialogContext.js
+++ b/client/src/context/DialogContext.js
@@ -1,11 +1,13 @@
-import React, {useState, createContext} from "react";
+import React, {useState, createContext, useContext} from "react";
 import "../style/Dialog.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faClose} from "@fortawesome/free-solid-svg-icons";
+import {SpeedtestContext} from "./SpeedtestContext";
 
 export const DialogContext = createContext();
 
 const Dialog = ({dialog, setDialog}) => {
+    const updateTests = useContext(SpeedtestContext)[1];
     const [value, setValue] = useState(dialog.value || "");
 
     document.onkeyup = e => {
@@ -55,16 +57,32 @@ const Dialog = ({dialog, setDialog}) => {
     if (dialog.speedtest) {
         dialog.promise.then(res => {
             if (res.status === 409) {
-                setDialog({title: "Fehlgeschlagen", description: "Es läuft bereits ein Speedtest. Bitte gedulde dich ein wenig, bis dieser fertig ist.", buttonText: "Okay"});
+                setDialog({
+                    title: "Fehlgeschlagen",
+                    description: "Es läuft bereits ein Speedtest. Bitte gedulde dich ein wenig, bis dieser fertig ist.",
+                    buttonText: "Okay"
+                });
             } else if (res.status === 410) {
-                setDialog({title: "Fehlgeschlagen", description: "Speedtests sind aktuell pausiert. Bitte setze sie fort, wenn du einen machen möchtest.", buttonText: "Okay"});
-            } else window.location.reload();
+                setDialog({
+                    title: "Fehlgeschlagen",
+                    description: "Speedtests sind aktuell pausiert. Bitte setze sie fort, wenn du einen machen möchtest.",
+                    buttonText: "Okay"
+                });
+            } else {
+                updateTests();
+                setDialog();
+            }
         });
 
         return (
             <div className="dialog-area">
                 <div className="dialog dialog-speedtest">
-                    <div className="lds-ellipsis"><div/><div/><div/><div/></div>
+                    <div className="lds-ellipsis">
+                        <div/>
+                        <div/>
+                        <div/>
+                        <div/>
+                    </div>
                 </div>
             </div>
         )
@@ -78,15 +96,18 @@ const Dialog = ({dialog, setDialog}) => {
                     <FontAwesomeIcon icon={faClose} className="dialog-text dialog-icon" onClick={closeDialog}/>
                 </div>
                 <div className="dialog-main">
-                    {dialog.description ? <h3 className="dialog-description">{dialog.description}</h3>: ""}
-                    {dialog.placeholder ? <input className="dialog-input" type={dialog.type ? dialog.type : "text"} placeholder={dialog.placeholder} value={value}
+                    {dialog.description ? <h3 className="dialog-description">{dialog.description}</h3> : ""}
+                    {dialog.placeholder ? <input className="dialog-input" type={dialog.type ? dialog.type : "text"}
+                                                 placeholder={dialog.placeholder} value={value}
                                                  onChange={updateValue}/> : ""}
                     {dialog.select ? <select value={value} onChange={updateValue} className="dialog-input">
-                        {Object.keys(dialog.selectOptions).map(key => <option key={key} value={key}>{dialog.selectOptions[key]}</option>)}
+                        {Object.keys(dialog.selectOptions).map(key => <option key={key}
+                                                                              value={key}>{dialog.selectOptions[key]}</option>)}
                     </select> : ""}
                 </div>
                 <div className="dialog-buttons">
-                    {dialog.unsetButton ? <button className="dialog-btn dialog-secondary" onClick={clear}>{dialog.unsetButtonText || "Entfernen"}</button> : ""}
+                    {dialog.unsetButton ? <button className="dialog-btn dialog-secondary"
+                                                  onClick={clear}>{dialog.unsetButtonText || "Entfernen"}</button> : ""}
                     <button className="dialog-btn" onClick={submit}>{dialog.buttonText || "Aktualisieren"}</button>
                 </div>
             </div>
@@ -99,7 +120,7 @@ export const DialogProvider = (props) => {
 
     return (
         <DialogContext.Provider value={[setDialog]}>
-            {dialog && <Dialog dialog={dialog} setDialog={setDialog}/>}
+            {dialog ? <Dialog dialog={dialog} setDialog={setDialog}/> : <></>}
             {props.children}
         </DialogContext.Provider>
     )

--- a/client/src/context/DialogContext.js
+++ b/client/src/context/DialogContext.js
@@ -13,19 +13,35 @@ const Dialog = ({dialog, setDialog}) => {
             e.preventDefault();
             submit();
         }
+        if (e.key === "Escape") {
+            e.preventDefault();
+            closeDialog();
+        }
     }
 
     function updateValue(e) {
         setValue(e.target.value);
     }
 
+    function hideTooltips(state) {
+        Array.from(document.getElementsByClassName("tooltip")).forEach(element => {
+            if (state && !element.classList.contains("tooltip-invisible")) {
+                element.classList.add("tooltip-invisible");
+            } else if (!state && element.classList.contains("tooltip-invisible")) {
+                element.classList.remove("tooltip-invisible");
+            }
+        });
+    }
+
     function closeDialog() {
         setDialog();
+        hideTooltips(false);
         if (dialog.onClose) dialog.onClose();
     }
 
     function submit() {
         setDialog();
+        hideTooltips(false);
         if (dialog.onSuccess) dialog.onSuccess(value);
     }
 
@@ -33,6 +49,8 @@ const Dialog = ({dialog, setDialog}) => {
         setDialog();
         if (dialog.onClear) dialog.onClear();
     }
+
+    hideTooltips(true);
 
     if (dialog.speedtest) {
         dialog.promise.then(res => {

--- a/client/src/context/DialogContext.js
+++ b/client/src/context/DialogContext.js
@@ -38,6 +38,8 @@ const Dialog = ({dialog, setDialog}) => {
         dialog.promise.then(res => {
             if (res.status === 409) {
                 setDialog({title: "Fehlgeschlagen", description: "Es läuft bereits ein Speedtest. Bitte gedulde dich ein wenig, bis dieser fertig ist.", buttonText: "Okay"});
+            } else if (res.status === 410) {
+                setDialog({title: "Fehlgeschlagen", description: "Speedtests sind aktuell pausiert. Bitte setze sie fort, wenn du einen machen möchtest.", buttonText: "Okay"});
             } else window.location.reload();
         });
 
@@ -59,7 +61,7 @@ const Dialog = ({dialog, setDialog}) => {
                 </div>
                 <div className="dialog-main">
                     {dialog.description ? <h3 className="dialog-description">{dialog.description}</h3>: ""}
-                    {dialog.placeholder ? <input className="dialog-input" type={dialog.password ? "password" : "text"} placeholder={dialog.placeholder} value={value}
+                    {dialog.placeholder ? <input className="dialog-input" type={dialog.type ? dialog.type : "text"} placeholder={dialog.placeholder} value={value}
                                                  onChange={updateValue}/> : ""}
                 </div>
                 <div className="dialog-buttons">

--- a/client/src/context/DialogContext.js
+++ b/client/src/context/DialogContext.js
@@ -63,6 +63,9 @@ const Dialog = ({dialog, setDialog}) => {
                     {dialog.description ? <h3 className="dialog-description">{dialog.description}</h3>: ""}
                     {dialog.placeholder ? <input className="dialog-input" type={dialog.type ? dialog.type : "text"} placeholder={dialog.placeholder} value={value}
                                                  onChange={updateValue}/> : ""}
+                    {dialog.select ? <select value={value} onChange={updateValue} className="dialog-input">
+                        {Object.keys(dialog.selectOptions).map(key => <option key={key} value={key}>{dialog.selectOptions[key]}</option>)}
+                    </select> : ""}
                 </div>
                 <div className="dialog-buttons">
                     {dialog.unsetButton ? <button className="dialog-btn dialog-secondary" onClick={clear}>{dialog.unsetButtonText || "Entfernen"}</button> : ""}

--- a/client/src/context/SpeedtestContext.js
+++ b/client/src/context/SpeedtestContext.js
@@ -1,0 +1,27 @@
+import React, {useState, createContext, useEffect} from "react";
+
+export const SpeedtestContext = createContext();
+
+export const SpeedtestProvider = (props) => {
+
+    const [speedtests, setSpeedtests] = useState({});
+
+    const updateTests = () => {
+        let passwordHeaders = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
+        fetch("/api/speedtests", {headers: passwordHeaders})
+            .then(res => res.json())
+            .then(tests => setSpeedtests(tests))
+    }
+
+    useEffect(() => {
+        updateTests();
+        const interval = setInterval(() => updateTests(), 15000);
+        return () => clearInterval(interval);
+    }, []);
+
+    return (
+        <SpeedtestContext.Provider value={[speedtests, updateTests]}>
+            {props.children}
+        </SpeedtestContext.Provider>
+    )
+}

--- a/client/src/style/Dialog.sass
+++ b/client/src/style/Dialog.sass
@@ -65,7 +65,7 @@
   cursor: pointer
 
 .dialog-input
-  width: 200px
+  width: 220px
   font-size: 18pt
   padding: 15px
   font-weight: 700

--- a/client/src/style/Dialog.sass
+++ b/client/src/style/Dialog.sass
@@ -65,7 +65,6 @@
   cursor: pointer
 
 .dialog-input
-  width: 220px
   font-size: 18pt
   padding: 15px
   font-weight: 700

--- a/client/src/style/Dropdown.sass
+++ b/client/src/style/Dropdown.sass
@@ -52,3 +52,7 @@
 .center
   display: flex
   justify-content: center
+
+@media (max-width: 390px)
+  .dropdown-content
+    left: 0

--- a/client/src/style/Dropdown.sass
+++ b/client/src/style/Dropdown.sass
@@ -4,7 +4,7 @@
   display: inline-block
   position: absolute
   width: 320px
-  height: 335px
+  height: 336px
   overflow: auto
   border-radius: 10px
   box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2)

--- a/client/src/style/Dropdown.sass
+++ b/client/src/style/Dropdown.sass
@@ -4,7 +4,6 @@
   display: inline-block
   position: absolute
   width: 320px
-  height: 336px
   overflow: auto
   border-radius: 10px
   box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2)

--- a/client/src/style/Header.sass
+++ b/client/src/style/Header.sass
@@ -5,24 +5,51 @@
   justify-content: space-between
   color: #F1F1F1
 
+.header-right
+  display: flex
+
+.header-right svg
+  margin-left: 15px
+
 .header-main *
   font-size: 24pt
 
 .header-main h2
   margin-left: 10%
 
-.header-main svg
+.header-main div
   margin-right: 10%
 
-.settings
+.header-icon
   cursor: pointer
   transition: all 50ms ease-in-out
   width: 30px
   height: 30px
 
-.settings:hover
+.header-icon:hover
   transform: scale(1.1)
 
-@media (max-width: 320px)
+@media (max-width: 425px)
+  .header-main
+    justify-content: center
+  .header-main div
+    margin-right: 0
   .header-main h2
     margin-left: 0
+    font-size: 18pt
+  .header-icon
+    width: 20px
+    height: 20px
+
+
+@media (max-width: 280px)
+  .header-main
+    justify-content: center
+  .header-main h2
+    margin-left: 0
+    font-size: 16pt
+    text-overflow: ellipsis
+    overflow: hidden
+  .header-icon
+    width: 16px
+    height: 16px

--- a/client/src/style/LatestTest.sass
+++ b/client/src/style/LatestTest.sass
@@ -2,9 +2,12 @@
   margin-top: 2rem
   display: flex
   padding: 3rem 2rem
+  border: #b5b5b5 1px solid
   border-radius: 15px
   width: 80rem
   flex-wrap: wrap
+
+.pulse
   animation: pulse 5s infinite
 
 @keyframes pulse

--- a/client/src/style/LatestTest.sass
+++ b/client/src/style/LatestTest.sass
@@ -2,10 +2,18 @@
   margin-top: 2rem
   display: flex
   padding: 3rem 2rem
-  border: #45c65a 1px solid
   border-radius: 15px
   width: 80rem
   flex-wrap: wrap
+  animation: pulse 5s infinite
+
+@keyframes pulse
+  0%
+    border: #45c65a 2px solid
+  50%
+    border: #2d7134 2px solid
+  100%
+    border: #45c65a 2px solid
 
 .inner-container
   margin-left: 2rem

--- a/client/src/style/LatestTest.sass
+++ b/client/src/style/LatestTest.sass
@@ -48,8 +48,15 @@
     margin: 1rem
 
 @media (max-width: 1351px)
+  .inner-container
+    margin-left: 1rem
+    margin-right: 1rem
   .analyse-area
-    flex-direction: column
+    width: 70rem
+
+@media (max-width: 1200px)
+  .analyse-area
+    justify-content: space-evenly
     width: 60rem
 
 @media (max-width: 1050px)
@@ -58,6 +65,7 @@
 
 @media (max-width: 730px)
   .analyse-area
+    flex-direction: column
     width: 32rem
 
 @media (max-width: 605px)

--- a/client/src/style/LatestTest.sass
+++ b/client/src/style/LatestTest.sass
@@ -2,7 +2,7 @@
   margin-top: 2rem
   display: flex
   padding: 3rem 2rem
-  border: #DFDFDF 1px solid
+  border: #45c65a 1px solid
   border-radius: 15px
   width: 80rem
   flex-wrap: wrap
@@ -14,6 +14,8 @@
 .container-header
   display: flex
 
+.tests-paused
+  border: #e58a00 2px solid
 
 .container-text
   margin: 0 0 0 25px

--- a/client/src/style/Speedtest.sass
+++ b/client/src/style/Speedtest.sass
@@ -36,13 +36,12 @@
   opacity: 0
   bottom: 120%
   left: 50%
-  width: 160px
   margin-left: -60px
   background-color: #1d2128
   color: #C8C8C8
   text-align: center
   border-radius: 6px
-  padding: 5px 5px
+  padding: 5px 10px
   height: fit-content
 
   z-index: 90
@@ -81,6 +80,8 @@
     font-size: 32pt
 
 @media (max-width: 475px)
+  .tooltip-element .tooltip
+    font-size: 12pt
   .speedtest
     width: 18rem
 

--- a/client/src/style/Speedtest.sass
+++ b/client/src/style/Speedtest.sass
@@ -32,19 +32,26 @@
   position: relative
 
 .tooltip-element .tooltip
+  font-size: 16pt
   opacity: 0
   bottom: 120%
   left: 50%
+  width: 160px
   margin-left: -60px
   background-color: #1d2128
   color: #C8C8C8
   text-align: center
   border-radius: 6px
   padding: 5px 5px
+  height: fit-content
 
   z-index: 90
   position: absolute
   transition: opacity 0.2s
+
+.tooltip-bottom .tooltip
+  bottom: 0
+  top: 120%
 
 .tooltip-element:hover .tooltip
   opacity: 1

--- a/client/src/style/Speedtest.sass
+++ b/client/src/style/Speedtest.sass
@@ -53,6 +53,9 @@
   bottom: 0
   top: 120%
 
+.tooltip-element .tooltip-invisible
+  visibility: hidden
+
 .tooltip-element:hover .tooltip
   opacity: 1
 

--- a/client/src/style/Speedtest.sass
+++ b/client/src/style/Speedtest.sass
@@ -28,6 +28,27 @@
   font-weight: 900
   color: #C8C8C8
 
+.tooltip-element
+  position: relative
+
+.tooltip-element .tooltip
+  opacity: 0
+  bottom: 120%
+  left: 50%
+  margin-left: -60px
+  background-color: #1d2128
+  color: #C8C8C8
+  text-align: center
+  border-radius: 6px
+  padding: 5px 5px
+
+  z-index: 90
+  position: absolute
+  transition: opacity 0.2s
+
+.tooltip-element:hover .tooltip
+  opacity: 1
+
 @media (max-width: 1351px)
   .speedtest
     width: 60rem

--- a/client/src/style/Speedtest.sass
+++ b/client/src/style/Speedtest.sass
@@ -60,6 +60,10 @@
 
 @media (max-width: 1351px)
   .speedtest
+    width: 70rem
+
+@media (max-width: 1200px)
+  .speedtest
     width: 60rem
 
 @media (max-width: 1050px)

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,21 @@ if [ $EUID -ne 0 ]; then
   exit
 fi
 
+echo -e "$GREEN ---------$BLUE Automatische Installation$GREEN ---------"
+echo -e "$BLUE MySpeed$YELLOW wird nun installiert."
+if [ "$1" == "--beta" ]; then
+  echo -e "$YELLOW Version:$BLUE MySpeed Beta"
+else
+  echo -e "$YELLOW Version:$BLUE MySpeed Release"
+fi
+echo -e "$YELLOW Es wird die Speedtest API von Ookla verwendet."
+echo -e "$YELLOW Wenn du damit$RED nicht$YELLOW einverstanden bist,"
+echo -e "$YELLOW kannst du die Installation mit$RED STRG + C$YELLOW abbrechen. "
+echo -e "$GREEN Die Installation beginnt in 5 Sekunden..."
+echo -e "$GREEN ----------------------------------------------"
+sleep 5
+clear
+
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
     echo -e "$YELLOW⚠ Warnung: $NORMAL MySpeed ist bereits auf diesem System installiert."

--- a/install.sh
+++ b/install.sh
@@ -143,12 +143,12 @@ fi
 
 echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
 sleep 2
-npm install
+npm install --force
 
 if [ "$1" == "--beta" ]; then
   echo -e "$BLUEℹ Info: $NORMAL Die Weboberfläche wird kompiliert..."
   sleep 2
-  cd client && npm install
+  cd client && npm install --force
   cd .. && npm run build
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ BLUE='\033[1;34m'
 YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NORMAL='\033[0;39m'
+PURPLE='\033[0;35m'
 
 
 INSTALLATION_PATH="/opt/myspeed"
@@ -19,7 +20,7 @@ fi
 echo -e "$GREEN ---------$BLUE Automatische Installation$GREEN ---------"
 echo -e "$BLUE MySpeed$YELLOW wird nun installiert."
 if [ "$1" == "--beta" ]; then
-  echo -e "$YELLOW Version:$BLUE MySpeed Beta"
+  echo -e "$YELLOW Version:$BLUE MySpeed$PURPLE Beta"
 else
   echo -e "$YELLOW Version:$BLUE MySpeed Release"
 fi

--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ echo -e "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
 if [ "$1" == "--beta" ]; then
   unzip -qo development.zip
-  mv myspeed-*/* .
+  cp myspeed-*/* .
   rm development.zip
   rm -R myspeed-development
 else

--- a/install.sh
+++ b/install.sh
@@ -17,18 +17,19 @@ log () {
 
 # Root check
 if [ $EUID -ne 0 ]; then
-  echo -e "$RED ✗ Fehler bei der Installation: $NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
+  echo -e "$RED✗ Fehler bei der Installation:$NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
   exit
 fi
 
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
-    echo -e "$YELLOW ⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. ($INSTALLATION_PATH)"
+    echo -e "$YELLOW⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. (Pfad: $INSTALLATION_PATH)"
     exit 0
 fi
 
 
 # Update all packages
+echo -e "$BLUE🔎 Status:$NORMAL Es wird nach neuen Updates für das Linux-System gesucht..."
 apt-get update -y
 
 clear
@@ -56,7 +57,7 @@ fi
 
 # Check for curl
 clear
-echo -e "$BLUE 🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
+echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
 if ! command -v curl &> /dev/null
 then
     echo -e "$YELLOWℹ\"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
@@ -66,7 +67,7 @@ fi
 
 # Check for node
 clear
-echo -e "$BLUE 🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
+echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
 if ! command -v node &> /dev/null
 then
     echo -e "$YELLOWℹ\"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
@@ -77,7 +78,7 @@ fi
 
 clear
 echo -e "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
-sleep 5
+sleep 3
 
 clear
 if [ ! -d $INSTALLATION_PATH ]
@@ -103,5 +104,8 @@ sleep 2
 npm install
 
 clear
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
-echo -e "Die Weboberfläche findest du unter $BLUEhttp://localhost:5216$NORMAL."
+echo -e "Die Weboberfläche findest du im Browser unter $BLUEhttp://localhost:5216$NORMAL."
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL" #multicolor
+# MySpeed is installed successfully.

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ fi
 clear
 if [ "$1" == "--beta" ]; then
   echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob build-essential vorhanden ist..."
-  if ! command -v build-essential &> /dev/null
+  if ! dpkg-query -l build-essential | grep build-essential &> /dev/null
   then
       echo -e "$YELLOWℹ \"build-essential\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
       sleep 2

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,8 @@ fi
 
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
-    echo -e "$YELLOW⚠ Warnung: $NORMAL MySpeed ist bereits auf diesem System installiert. Es wird nun unter $INSTALLATION_PATH aktualisiert."
+    echo -e "$YELLOW⚠ Warnung: $NORMAL MySpeed ist bereits auf diesem System installiert."
+    echo -e "$GREENℹ Info:$NORMAL Es wird nun der aktuelle Release installiert..."
     sleep 5
 fi
 
@@ -125,8 +126,9 @@ EOF
 fi
 
 if ! command -v systemctl &> /dev/null; then
-    echo -e "$YELLOW⚠ Warnung: $NORMAL Dein System unterstützt die Installation als Hintergrunddienst nicht."
-    exit 0
+    echo -e "$YELLOW⚠ Warnung: $NORMAL Dein Linux-System bietet derzeit nicht die Möglichkeit, MySpeed im Hintergrund zu starten. Hierfür wird \"systemd\" benötigt."
+    echo -e "$BLUEℹ Info: $NORMAL Du kannst, wenn du \"systemd\" installiert hast, die Installation erneut starten. Es wird dann automatisch eingestellt."
+    sleep 2
 fi
 
 clear

--- a/install.sh
+++ b/install.sh
@@ -125,13 +125,14 @@ EOF
   systemctl start myspeed
 fi
 
+clear
+
 if ! command -v systemctl &> /dev/null; then
     echo -e "$YELLOW⚠ Warnung: $NORMAL Dein Linux-System bietet derzeit nicht die Möglichkeit, MySpeed im Hintergrund zu starten. Hierfür wird \"systemd\" benötigt."
     echo -e "$BLUEℹ Info: $NORMAL Du kannst, wenn du \"systemd\" installiert hast, die Installation erneut starten. Es wird dann automatisch eingestellt."
-    sleep 2
+    sleep 5
 fi
 
-clear
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
 echo -e "Die Weboberfläche findest du im Browser unter$BLUE http://localhost:5216$NORMAL."

--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ npm install
 # Install as system service
 clear
 echo -e "$BLUE🔎 Status:$NORMAL Registriere MySpeed als Hintergrunddienst..."
-if systemctl --all --type service | grep -q "myspeed.service"; then
+if ! systemctl --all --type service | grep -n "myspeed.service"; then
   cat << EOF >> /etc/systemd/system/myspeed.service
   [Unit]
   Description=MySpeed

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,19 @@ then
     apt-get install unzip -y
 fi
 
+# Check for build essential
+clear
+if [ "$1" == "--beta" ]; then
+  echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob build-essential vorhanden ist..."
+  if ! command -v build-essential &> /dev/null
+  then
+      echo -e "$YELLOWℹ \"build-essential\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+      sleep 2
+      apt-get install build-essential -y
+  fi
+fi
+
+
 # Check for curl
 clear
 echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
@@ -69,11 +82,18 @@ then
     echo -e "$YELLOWℹ \"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
-    apt-get install nodejs npm -y
+    apt-get install nodejs -y
 fi
 
 clear
-RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+
+if [ "$1" == "--beta" ]; then
+  RELEASE_URL=https://github.com/gnmyt/myspeed/archive/refs/heads/development.zip
+else
+  RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+fi
+
+
 echo -e "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
 sleep 3
 
@@ -93,12 +113,27 @@ wget "$RELEASE_URL"
 
 echo -e "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
-unzip -qo MySpeed*.zip
-rm MySpeed-*.zip
+if [ "$1" == "--beta" ]; then
+  unzip -qo development.zip
+  mv myspeed-*/* .
+  rm development.zip
+  rm -R myspeed-development
+else
+  unzip -qo MySpeed*.zip
+  rm MySpeed-*.zip
+fi
+
 
 echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
 sleep 2
 npm install
+
+if [ "$1" == "--beta" ]; then
+  echo -e "$BLUEℹ Info: $NORMAL Die Weboberfläche wird kompiliert..."
+  sleep 2
+  cd client && npm install
+  cd .. && npm run build
+fi
 
 # Install as system service
 clear

--- a/install.sh
+++ b/install.sh
@@ -124,8 +124,6 @@ EOF
   systemctl start myspeed
 fi
 
-systemctl status myspeed
-
 clear
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ clear
 echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob wget vorhanden ist..."
 if ! command -v wget &> /dev/null
 then
-    echo -e "$YELLOWℹ\"wget\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ \"wget\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install wget -y
 fi
@@ -50,7 +50,7 @@ clear
 echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob unzip vorhanden ist..."
 if ! command -v unzip &> /dev/null
 then
-    echo -e "$YELLOWℹ\"unzip\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ \"unzip\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install unzip -y
 fi
@@ -60,7 +60,7 @@ clear
 echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
 if ! command -v curl &> /dev/null
 then
-    echo -e "$YELLOWℹ\"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ \"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install curl -y
 fi
@@ -70,7 +70,7 @@ clear
 echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
 if ! command -v node &> /dev/null
 then
-    echo -e "$YELLOWℹ\"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ \"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
     apt-get install nodejs -y
@@ -104,8 +104,8 @@ sleep 2
 npm install
 
 clear
-echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL" #multicolor
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
-echo -e "Die Weboberfläche findest du im Browser unter $BLUEhttp://localhost:5216$NORMAL."
-echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL$GREEN-$NORMAL" #multicolor
+echo -e "Die Weboberfläche findest du im Browser unter$BLUE http://localhost:5216$NORMAL."
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 # MySpeed is installed successfully.

--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ then
     echo -e "$YELLOWℹ \"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
-    apt-get install nodejs -y
+    apt-get install nodejs npm -y
 fi
 
 clear

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,8 @@ if [ "$1" == "--beta" ]; then
   sleep 2
   cd client && npm install --force
   cd .. && npm run build
+  cp -r client/build .
+  rm -rf client/build
 fi
 
 # Install as system service

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ wget "$RELEASE_URL"
 
 echo -e "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
-unzip MySpeed*.zip
+unzip -qo MySpeed*.zip
 rm MySpeed-*.zip
 
 echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."

--- a/install.sh
+++ b/install.sh
@@ -191,6 +191,9 @@ fi
 
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
-echo -e "Die Weboberfläche findest du im Browser unter$BLUE http://localhost:5216$NORMAL."
+echo -e "Die Weboberfläche findest du im Browser unter$BLUE http://$(curl -s ifconfig.me):5216$NORMAL."
+if [ -d $INSTALLATION_PATH ]; then
+  echo -e "$BLUEℹ Info:$NORMAL Sollte das Update nicht erfolgreich angewendet worden sein, bitte starte MySpeed mal neu:$BLUE systemctl restart myspeed"
+fi
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 # MySpeed is installed successfully.

--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,8 @@ echo -e "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
 if [ "$1" == "--beta" ]; then
   unzip -qo development.zip
-  cp myspeed-*/* .
+  rm -R server client
+  mv myspeed-*/* .
   rm development.zip
   rm -R myspeed-development
 else

--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ if ! command -v systemctl &> /dev/null; then
     echo -e "$YELLOW⚠ Warnung: $NORMAL Dein Linux-System bietet derzeit nicht die Möglichkeit, MySpeed im Hintergrund zu starten. Hierfür wird \"systemd\" benötigt."
     echo -e "$BLUEℹ Info: $NORMAL Du kannst, wenn du \"systemd\" installiert hast, die Installation erneut starten. Es wird dann automatisch eingestellt."
     sleep 5
-elif [ ! -d $INSTALLATION_PATH ]; then
+else
   systemctl restart myspeed
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,33 @@ echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt ins
 sleep 2
 npm install
 
+# Install as system service
+clear
+echo -e "$BLUE🔎 Status:$NORMAL Registriere MySpeed als Hintergrunddienst..."
+if systemctl --all --type service | grep -q "myspeed.service"; then
+  cat << EOF >> /etc/systemd/system/myspeed.service
+  [Unit]
+  Description=MySpeed
+  After=network.target
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/node server
+  Restart=always
+  User=root
+  Environment=NODE_ENV=production
+  WorkingDirectory=/opt/myspeed
+
+  [Install]
+  WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable myspeed
+  systemctl start myspeed
+fi
+
+systemctl status myspeed
+
 clear
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,10 @@ if [ -d $INSTALLATION_PATH ]; then
     sleep 5
 fi
 
+if command -v systemctl &> /dev/null && systemctl --all --type service | grep -n "myspeed.service"; then
+  systemctl stop myspeed
+fi
+
 
 # Update all packages
 echo -e "$BLUE🔎 Status:$NORMAL Es wird nach neuen Updates für das Linux-System gesucht..."

--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ fi
 
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
-    echo -e "$YELLOW⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. (Pfad: $INSTALLATION_PATH)"
-    exit 0
+    echo -e "$YELLOW⚠ Warnung: $NORMAL MySpeed ist bereits auf diesem System installiert. Es wird nun unter $INSTALLATION_PATH aktualisiert."
+    sleep 5
 fi
 
 
@@ -102,7 +102,7 @@ npm install
 # Install as system service
 clear
 echo -e "$BLUE🔎 Status:$NORMAL Registriere MySpeed als Hintergrunddienst..."
-if ! systemctl --all --type service | grep -n "myspeed.service"; then
+if command -v systemctl &> /dev/null && ! systemctl --all --type service | grep -n "myspeed.service"; then
   cat << EOF >> /etc/systemd/system/myspeed.service
   [Unit]
   Description=MySpeed
@@ -122,6 +122,11 @@ EOF
   systemctl daemon-reload
   systemctl enable myspeed
   systemctl start myspeed
+fi
+
+if ! command -v systemctl &> /dev/null; then
+    echo -e "$YELLOW⚠ Warnung: $NORMAL Dein System unterstützt die Installation als Hintergrunddienst nicht."
+    exit 0
 fi
 
 clear

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,6 @@ NORMAL='\033[0;39m'
 
 
 INSTALLATION_PATH="/opt/myspeed"
-RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
 
 # Root check
 if [ $EUID -ne 0 ]; then
@@ -73,6 +72,7 @@ then
 fi
 
 clear
+RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
 echo -e "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
 sleep 3
 

--- a/install.sh
+++ b/install.sh
@@ -17,16 +17,13 @@ log () {
 
 # Root check
 if [ $EUID -ne 0 ]; then
-  echo "$RED ✗ Fehler bei der Installation: $NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
-  echo "$BLUE Die Root-Abfrage wird ausgeführt, bitte gib das dazugehörige Passwort ein. Die Installation wird dann automatisch neu gestartet. Um abzubrechen, drücke STRG+C."
-  sudo -s
-  curl -sSL https://raw.githubusercontent.com/gnmyt/myspeed/release/install.sh | bash
+  echo -e "$RED ✗ Fehler bei der Installation: $NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
   exit
 fi
 
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
-    echo "$YELLOW ⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. ($INSTALLATION_PATH)"
+    echo -e "$YELLOW ⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. ($INSTALLATION_PATH)"
     exit 0
 fi
 
@@ -35,76 +32,76 @@ fi
 apt-get update -y
 
 clear
-echo "$GREENℹ Info:$NORMAL Die Installation wird jetzt vorbereitet. Das kann einen Augenblick dauern..."
+echo -e "$GREENℹ Info:$NORMAL Die Installation wird jetzt vorbereitet. Das kann einen Augenblick dauern..."
 sleep 5
 # Check for wget
 clear
-echo "$BLUE🔎 Status:$NORMAL Überprüfe, ob wget vorhanden ist..."
+echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob wget vorhanden ist..."
 if ! command -v wget &> /dev/null
 then
-    echo "$YELLOWℹ\"wget\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ\"wget\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install wget -y
 fi
 
 # Check for unzip
 clear
-echo "$BLUE🔎 Status:$NORMAL Überprüfe, ob unzip vorhanden ist..."
+echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob unzip vorhanden ist..."
 if ! command -v unzip &> /dev/null
 then
-    echo "$YELLOWℹ\"unzip\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ\"unzip\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install unzip -y
 fi
 
 # Check for curl
 clear
-echo "$BLUE 🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
+echo -e "$BLUE 🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
 if ! command -v curl &> /dev/null
 then
-    echo "$YELLOWℹ\"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ\"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install curl -y
 fi
 
 # Check for node
 clear
-echo "$BLUE 🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
+echo -e "$BLUE 🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
 if ! command -v node &> /dev/null
 then
-    echo "$YELLOWℹ\"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ\"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
     apt-get install nodejs -y
 fi
 
 clear
-echo "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
+echo -e "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
 sleep 5
 
 clear
 if [ ! -d $INSTALLATION_PATH ]
 then
-    echo "$BLUEℹ Info: $NORMAL MySpeed wird unter dem Verzeichnis $INSTALLATION_PATH installiert. Der Ordner wird nun erstellt."
+    echo -e "$BLUEℹ Info: $NORMAL MySpeed wird unter dem Verzeichnis $INSTALLATION_PATH installiert. Der Ordner wird nun erstellt."
     sleep 2
     mkdir $INSTALLATION_PATH
 fi
 
 cd $INSTALLATION_PATH
 
-echo "$BLUEℹ Info: $NORMAL Die aktuelle MySpeed-Instanz wird heruntergeladen. Einen Moment..."
+echo -e "$BLUEℹ Info: $NORMAL Die aktuelle MySpeed-Instanz wird heruntergeladen. Einen Moment..."
 sleep 2
 wget "$RELEASE_URL"
 
-echo "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
+echo -e "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
 unzip MySpeed*.zip
 rm MySpeed-*.zip
 
-echo "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
+echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
 sleep 2
 npm install
 
 clear
-echo "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
-echo "Die Weboberfläche findest du unter $BLUEhttp://localhost:5216$NORMAL."
+echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
+echo -e "Die Weboberfläche findest du unter $BLUEhttp://localhost:5216$NORMAL."

--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,6 @@ NORMAL='\033[0;39m'
 INSTALLATION_PATH="/opt/myspeed"
 RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
 
-log () {
-    printf "\033[0;34m$1\e[0m\n"
-}
-
 # Root check
 if [ $EUID -ne 0 ]; then
   echo -e "$RED✗ Fehler bei der Installation:$NORMAL Du benötigst Root-Rechte, um die Installation zu starten."

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,8 @@ if ! command -v systemctl &> /dev/null; then
     echo -e "$YELLOW⚠ Warnung: $NORMAL Dein Linux-System bietet derzeit nicht die Möglichkeit, MySpeed im Hintergrund zu starten. Hierfür wird \"systemd\" benötigt."
     echo -e "$BLUEℹ Info: $NORMAL Du kannst, wenn du \"systemd\" installiert hast, die Installation erneut starten. Es wird dann automatisch eingestellt."
     sleep 5
+elif [ ! -d $INSTALLATION_PATH ]; then
+  systemctl restart myspeed
 fi
 
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Colors for better overview
+GREEN='\033[0;32m'
+BLUE='\033[1;34m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+NORMAL='\033[0;39m'
+
+
 INSTALLATION_PATH="/opt/myspeed"
 RELEASE_URL=$(curl -s https://api.github.com/repos/gnmyt/myspeed/releases/latest | grep browser_download_url | cut -d '"' -f 4)
 
@@ -9,13 +17,16 @@ log () {
 
 # Root check
 if [ $EUID -ne 0 ]; then
-  echo "Du musst dieses Skript als root ausführen"
+  echo "$RED ✗ Fehler bei der Installation: $NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
+  echo "$BLUE Die Root-Abfrage wird ausgeführt, bitte gib das dazugehörige Passwort ein. Die Installation wird dann automatisch neu gestartet. Um abzubrechen, drücke STRG+C."
+  sudo -s
+  curl -sSL https://raw.githubusercontent.com/gnmyt/myspeed/release/install.sh | bash
   exit
 fi
 
 # Check if installed
 if [ -d $INSTALLATION_PATH ]; then
-    log "Eine MySpeed-Instanz unter $INSTALLATION_PATH wurde bereits installiert. Die Installation wird abgebrochen."
+    echo "$YELLOW ⚠ Fehler bei der Installation: $NORMAL MySpeed ist bereits auf diesem System installiert. ($INSTALLATION_PATH)"
     exit 0
 fi
 
@@ -23,63 +34,77 @@ fi
 # Update all packages
 apt-get update -y
 
+clear
+echo "$GREENℹ Info:$NORMAL Die Installation wird jetzt vorbereitet. Das kann einen Augenblick dauern..."
+sleep 5
 # Check for wget
+clear
+echo "$BLUE🔎 Status:$NORMAL Überprüfe, ob wget vorhanden ist..."
 if ! command -v wget &> /dev/null
 then
-    log "Das Paket \"wget\" wurde nicht gefunden, wird aber benötigt. Es wird nun installiert..."
+    echo "$YELLOWℹ\"wget\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install wget -y
 fi
 
 # Check for unzip
+clear
+echo "$BLUE🔎 Status:$NORMAL Überprüfe, ob unzip vorhanden ist..."
 if ! command -v unzip &> /dev/null
 then
-    log "Das Paket \"unzip\" wurde nicht gefunden, wird aber benötigt. Es wird nun installiert..."
+    echo "$YELLOWℹ\"unzip\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install unzip -y
 fi
 
 # Check for curl
+clear
+echo "$BLUE 🔎 Status:$NORMAL Überprüfe, ob curl vorhanden ist..."
 if ! command -v curl &> /dev/null
 then
-    log "Das Paket \"curl\" wurde nicht gefunden, wird aber benötigt. Es wird nun installiert..."
+    echo "$YELLOWℹ\"curl\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     apt-get install curl -y
 fi
 
 # Check for node
+clear
+echo "$BLUE 🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
 if ! command -v node &> /dev/null
 then
-    log "Das Paket \"nodejs\" wurde nicht gefunden, wird aber benötigt. Es wird nun installiert..."
+    echo "$YELLOWℹ\"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
     sleep 2
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
     apt-get install nodejs -y
 fi
 
-log "Alle notwendigen Pakete sind installiert. Starte installation von MySpeed..."
-sleep 2
+clear
+echo "$GREEN✓ Vorbereitung abgeschlossen:$NORMAL Die Installation von MySpeed wird jetzt gestartet..."
+sleep 5
 
+clear
 if [ ! -d $INSTALLATION_PATH ]
 then
-    log "MySpeed wird unter $INSTALLATION_PATH installiert. Der Ordner wird nun erstellt."
+    echo "$BLUEℹ Info: $NORMAL MySpeed wird unter dem Verzeichnis $INSTALLATION_PATH installiert. Der Ordner wird nun erstellt."
     sleep 2
     mkdir $INSTALLATION_PATH
 fi
 
 cd $INSTALLATION_PATH
 
-log "Lade notwendige Daten herunter..."
+echo "$BLUEℹ Info: $NORMAL Die aktuelle MySpeed-Instanz wird heruntergeladen. Einen Moment..."
 sleep 2
 wget "$RELEASE_URL"
 
-log "Entpacke notwendige Daten..."
+echo "$BLUEℹ Info: $NORMAL Download abgeschlossen. Entpacken läuft..."
 sleep 2
 unzip MySpeed*.zip
 rm MySpeed-*.zip
 
-log "Lade die notwendigen Abhängigkeiten herunter..."
+echo "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
 sleep 2
 npm install
 
 clear
-log "Erfolg! MySpeed wurde unter $INSTALLATION_PATH installiert."
+echo "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
+echo "Die Weboberfläche findest du unter $BLUEhttp://localhost:5216$NORMAL."

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "myspeed",
       "version": "1.0.2",
       "dependencies": {
+        "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
         "better-sqlite3": "^7.5.0",
         "express": "^4.17.3",
@@ -74,6 +75,25 @@
       "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
@@ -280,6 +300,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -668,6 +702,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1014,6 +1059,14 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -1504,6 +1557,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2391,25 +2476,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-pre-gyp": {
       "version": "0.11.0",
@@ -3647,7 +3713,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -4019,6 +4085,14 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
           "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
         },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
         "nopt": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -4176,6 +4250,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -4460,6 +4548,14 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4738,6 +4834,11 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5129,6 +5230,21 @@
             "ee-first": "1.1.1"
           }
         }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -5785,14 +5901,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "node-pre-gyp": {
       "version": "0.11.0",
@@ -6746,7 +6854,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tree-kill": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "bcrypt": "^5.0.1",
         "better-sqlite3": "^7.5.0",
         "express": "^4.17.3",
+        "node-schedule": "^2.1.0",
         "speedtest-net": "^2.2.0"
       },
       "devDependencies": {
@@ -545,6 +546,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -818,6 +831,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cron-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
+      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "dependencies": {
+        "is-nan": "^1.3.2",
+        "luxon": "^1.26.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -1059,6 +1084,21 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1651,6 +1691,11 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "node_modules/gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -1716,6 +1761,19 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-proxy": {
@@ -1819,6 +1877,17 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1828,12 +1897,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-to-string-tag-x": {
@@ -2074,6 +2165,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -2211,6 +2317,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
+    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -2228,6 +2339,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/lzma-native": {
@@ -2590,6 +2709,19 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
+    "node_modules/node-schedule": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.0.tgz",
+      "integrity": "sha512-nl4JTiZ7ZQDc97MmpTq9BQjYhq7gOtoh7SiPH069gBFBj0PzD8HI7zyFs6rzqL8Y5tTiEEYLxgtbx034YPrbyQ==",
+      "dependencies": {
+        "cron-parser": "^3.5.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/nodemon": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
@@ -2756,6 +2888,14 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/once": {
@@ -3408,6 +3548,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",
@@ -4433,6 +4578,15 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4645,6 +4799,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "cron-parser": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
+      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "requires": {
+        "is-nan": "^1.3.2",
+        "luxon": "^1.26.0"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -4834,6 +4997,15 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -5291,6 +5463,11 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -5344,6 +5521,16 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-proxy": {
       "version": "2.1.0",
@@ -5422,16 +5609,37 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -5603,6 +5811,15 @@
         "is-path-inside": "^3.0.2"
       }
     },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -5707,6 +5924,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -5719,6 +5941,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "lzma-native": {
       "version": "4.0.6",
@@ -5995,6 +6222,16 @@
         }
       }
     },
+    "node-schedule": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.0.tgz",
+      "integrity": "sha512-nl4JTiZ7ZQDc97MmpTq9BQjYhq7gOtoh7SiPH069gBFBj0PzD8HI7zyFs6rzqL8Y5tTiEEYLxgtbx034YPrbyQ==",
+      "requires": {
+        "cron-parser": "^3.5.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      }
+    },
     "nodemon": {
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
@@ -6125,6 +6362,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "once": {
       "version": "1.4.0",
@@ -6607,6 +6849,11 @@
       "requires": {
         "sort-keys": "^1.0.0"
       }
+    },
+    "sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "spawn-command": {
       "version": "0.0.2-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myspeed",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "myspeed",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "better-sqlite3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myspeed",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "client": "cd client && npm start",
     "server": "nodemon server",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "client": "cd client && npm start",
     "server": "nodemon server",
-    "build": "cd client && npm run build && mv build ..",
+    "build": "cd client && npm run build",
     "dev": "concurrently --kill-others-on-fail \"npm run server\" \"npm run client\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bcrypt": "^5.0.1",
     "better-sqlite3": "^7.5.0",
     "express": "^4.17.3",
+    "node-schedule": "^2.1.0",
     "speedtest-net": "^2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "concurrently --kill-others-on-fail \"npm run server\" \"npm run client\""
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
     "better-sqlite3": "^7.5.0",
     "express": "^4.17.3",

--- a/server/controller/pause.js
+++ b/server/controller/pause.js
@@ -1,0 +1,18 @@
+let currentState = false;
+let updateTimer;
+
+// Update the current state directly
+module.exports.updateState = function(newState) {
+    this.currentState = newState;
+}
+
+// Update the current state in a specific time
+module.exports.resumeIn = function(time) {
+    if (updateTimer !== null) 
+        clearTimeout(updateTimer);
+
+    this.updateState(true);
+    updateTimer = setTimeout(() => this.updateState(false), time * 3600000); // time in hours
+}
+
+module.exports.currentState = currentState;

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -1,24 +1,36 @@
 const db = require('../index').database;
 
 // Inserts a new speedtest into the database
-module.exports.create = (ping, download, upload) => {
-    return db.prepare("INSERT INTO speedtests (ping, download, upload, created) VALUES (?, ?, ?, ?)").run(ping, download, upload,
-        new Date().toISOString()).lastInsertRowid;
+module.exports.create = (ping, download, upload, time, type = "auto", error = null) => {
+    return db.prepare("INSERT INTO speedtests (ping, download, upload, created, error, time, type) VALUES (?, ?, ?, ?, ?, ?, ?)").run(ping, download, upload,
+        new Date().toISOString(), error, time, type).lastInsertRowid;
 }
 
 // Gets a specific speedtest by id
 module.exports.get = (id) => {
-    return db.prepare("SELECT * FROM speedtests WHERE id = ?").get(id);
+    let speedtest = db.prepare("SELECT * FROM speedtests WHERE id = ?").get(id);
+    if (speedtest.error === null) delete speedtest.error;
+    return speedtest
 }
 
 // Lists all speedtests from the database
 module.exports.list = () => {
-    return db.prepare("SELECT * FROM speedtests ORDER BY created DESC").all();
+    let dbEntries = db.prepare("SELECT * FROM speedtests ORDER BY created DESC").all();
+    let all = [];
+
+    dbEntries.forEach((entry) => {
+        if (entry.error === null) delete entry.error
+        all.push(entry);
+    });
+
+    return all;
 }
 
 // Gets the latest speedtest from the database
 module.exports.latest = () => {
-    return db.prepare("SELECT * FROM speedtests ORDER BY id DESC").get();
+    let speedtest = db.prepare("SELECT * FROM speedtests ORDER BY id DESC").get();
+    if (speedtest != null && speedtest.error === null) delete speedtest.error;
+    return speedtest
 }
 
 // Deletes a specific speedtest

--- a/server/controller/tables.js
+++ b/server/controller/tables.js
@@ -2,10 +2,10 @@ const db = require('../index').database;
 
 const configDefaults = {
     "setupDone": "true",
-    "ping": 25,
-    "download": 100,
-    "upload": 50,
-    "timeLevel": 3,
+    "ping": "25",
+    "download": "100",
+    "upload": "50",
+    "timeLevel": "3",
     "serverId": "none",
     "password": "none"
 }

--- a/server/controller/tables.js
+++ b/server/controller/tables.js
@@ -5,6 +5,7 @@ const configDefaults = {
     "ping": 25,
     "download": 100,
     "upload": 50,
+    "timeLevel": 3,
     "serverId": "none",
     "password": "none"
 }

--- a/server/controller/tables.js
+++ b/server/controller/tables.js
@@ -19,6 +19,9 @@ module.exports.create = () => {
         "    ping     integer(5000)," +
         "    download double," +
         "    upload double," +
+        "    error varchar(255)," +
+        "    type varchar(255)," +
+        "    time double," +
         "    created DATETIME DEFAULT CURRENT_TIMESTAMP);");
     db.exec("create table if not exists recommendations(" +
         "    id       integer primary key autoincrement," +

--- a/server/index.js
+++ b/server/index.js
@@ -42,6 +42,7 @@ app.use("/api/*", require('./middlewares/password'));
 app.use("/api/config", require('./routes/config'));
 app.use("/api/speedtests", require('./routes/speedtests'));
 app.use("/api/info", require('./routes/system'));
+app.use("/api/export", require('./routes/export'));
 app.use("/api/recommendations", require('./routes/recommendations'));
 app.use("/api*", (req, res) => res.status(404).json({message: "Route not found"}));
 

--- a/server/index.js
+++ b/server/index.js
@@ -26,6 +26,9 @@ try {
 
 module.exports.database = db;
 
+// Create servers.json
+require('./tasks/loadServers');
+
 // Start all timer
 timerTask.startTimer();
 let removeInterval = setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);

--- a/server/index.js
+++ b/server/index.js
@@ -29,13 +29,13 @@ module.exports.database = db;
 // Create servers.json
 require('./tasks/loadServers');
 
-// Start all timer
-timerTask.startTimer();
-let removeInterval = setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
-
 // Create all tables & insert the defaults
 require("./controller/tables").create();
 require("./controller/tables").insert();
+
+// Start all timer
+timerTask.startTimer(require('./controller/config').get("timeLevel"));
+let removeInterval = setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
 
 // Register middlewares
 app.use(express.json());

--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,11 @@ if (process.env.NODE_ENV === 'production') {
     app.get('*', (req, res) => {
         res.sendFile(path.join(__dirname, '../build', 'index.html'));
     });
+} else {
+    app.get("*", (req, res) => {
+        res.status(500).send("<h2>Diese MySpeed-Instanz befindet sich aktuell im Entwicklungsmodus.<br/><br/>"
+            + "Wenn du der Betreiber bist, bitte ändere deine Umgebungsvariable ab.</h2>");
+    });
 }
 
 // Make a speedtest

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
+const timerTask = require('./tasks/timer');
 
 const app = express();
 const port = process.env.port || 5216;
@@ -25,7 +26,8 @@ try {
 
 module.exports.database = db;
 
-let interval = setInterval(async () => require('./tasks/speedtest').create(), 3600000); // run a speedtest every 1 hour
+// Start all timer
+timerTask.startTimer();
 let removeInterval = setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
 
 // Create all tables & insert the defaults
@@ -58,6 +60,6 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // Make a speedtest
-require('./tasks/speedtest').create();
+timerTask.runTask();
 
 app.listen(port, () => console.log(`Server listening on port ${port}`));

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ require("./controller/tables").create();
 require("./controller/tables").insert();
 
 // Start all timer
-timerTask.startTimer(require('./controller/config').get("timeLevel"));
+timerTask.startTimer(require('./controller/config').get("timeLevel").value);
 let removeInterval = setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
 
 // Register middlewares

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -1,5 +1,6 @@
 const app = require('express').Router();
 const config = require('../controller/config');
+const timer = require('../tasks/timer');
 
 // Gets all config entries
 app.get("/", (req, res) => {
@@ -22,12 +23,18 @@ app.get("/:key", (req, res) => {
 app.patch("/:key", async (req, res) => {
     if (!req.body.value) return res.status(400).json({message: "You need to provide the new value"});
 
-    if ((req.params.key === "ping" || req.params.key === "download" || req.params.key === "upload") && isNaN(req.body.value))
+    if ((req.params.key === "ping" || req.params.key === "download" || req.params.key === "upload" || req.params.key === "timeLevel") && isNaN(req.body.value))
         return res.status(400).json({message: "You need to provide a number in order to change this"});
 
     if (req.params.key === "password" && req.body.value !== "none") req.body.value = await require('bcrypt').hash(req.body.value, 10);
 
     if (!config.update(req.params.key, req.body.value)) return res.status(404).json({message: "The provided key does not exist"});
+
+    if (req.params.key === "timeLevel") {
+        timer.stopTimer();
+        timer.startTimer();
+    }
+
     res.json({message: `The key '${req.params.key}' has been successfully updated`});
 });
 

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -26,6 +26,9 @@ app.patch("/:key", async (req, res) => {
     if ((req.params.key === "ping" || req.params.key === "download" || req.params.key === "upload" || req.params.key === "timeLevel") && isNaN(req.body.value))
         return res.status(400).json({message: "You need to provide a number in order to change this"});
 
+    if (req.params.key === "ping")
+        req.body.value = req.body.value.split(".")[0];
+
     if (req.params.key === "password" && req.body.value !== "none") req.body.value = await require('bcrypt').hash(req.body.value, 10);
 
     if (!config.update(req.params.key, req.body.value)) return res.status(404).json({message: "The provided key does not exist"});

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -32,7 +32,7 @@ app.patch("/:key", async (req, res) => {
 
     if (req.params.key === "timeLevel") {
         timer.stopTimer();
-        timer.startTimer();
+        timer.startTimer(req.body.value);
     }
 
     res.json({message: `The key '${req.params.key}' has been successfully updated`});

--- a/server/routes/export.js
+++ b/server/routes/export.js
@@ -1,0 +1,24 @@
+const app = require('express').Router();
+const tests = require('../controller/speedtests');
+
+
+app.get("/json", async (req, res) => {
+    res.set({"Content-Disposition": "attachment; filename=\"speedtests.json\""});
+    res.send(JSON.stringify(tests.list(), null, 4));
+});
+
+app.get("/csv", async (req, res) => {
+    res.set({"Content-Disposition": "attachment; filename=\"speedtests.csv\""});
+    let list = tests.list();
+    let fields = Object.keys(list[0]);
+
+    let replacer = (key, value) => value === null ? '' : value
+
+    let csv = list.map(row => fields.map(fieldName => JSON.stringify(row[fieldName], replacer)).join(','));
+    csv.unshift(fields.join(','))
+    csv = csv.join('\r\n');
+
+    res.send(csv);
+});
+
+module.exports = app;

--- a/server/routes/speedtests.js
+++ b/server/routes/speedtests.js
@@ -10,7 +10,7 @@ app.get("/", (req, res) => {
 // Runs a speedtest
 app.post("/run", async (req, res) => {
     if (pauseController.currentState) return res.status(410).json({message: "The speedtests are currently paused"});
-    let speedtest = await require("../tasks/speedtest").create();
+    let speedtest = await require("../tasks/speedtest").create("custom");
     if (speedtest !== undefined) return res.status(409).json({message: "An speedtest is already running"});
     res.json({message: "Speedtest successfully created"});
 });

--- a/server/routes/speedtests.js
+++ b/server/routes/speedtests.js
@@ -1,5 +1,6 @@
 const app = require('express').Router();
 const tests = require('../controller/speedtests');
+const pauseController = require('../controller/pause');
 
 // List all speedtests
 app.get("/", (req, res) => {
@@ -8,6 +9,7 @@ app.get("/", (req, res) => {
 
 // Runs a speedtest
 app.post("/run", async (req, res) => {
+    if (pauseController.currentState) return res.status(410).json({message: "The speedtests are currently paused"});
     let speedtest = await require("../tasks/speedtest").create();
     if (speedtest !== undefined) return res.status(409).json({message: "An speedtest is already running"});
     res.json({message: "Speedtest successfully created"});
@@ -18,6 +20,30 @@ app.get("/latest", (req, res) => {
     let latest = tests.latest();
     if (latest === undefined) return res.status(404).json({message: "No speedtest has been made yet"});
     res.json(latest);
+});
+
+// Get the current pause status
+app.get("/status", (req, res) => {
+    res.json({paused: pauseController.currentState});
+});
+
+// Pauses all speedtests
+app.post("/pause", (req, res) => {
+    if (!req.body.resumeIn) return res.status(400).json({message: "You need to provide when to resume"});
+
+    if (req.body.resumeIn === -1) {
+        pauseController.updateState(true);
+    } else {
+        pauseController.resumeIn(req.body.resumeIn);
+    }
+    
+    res.json({message: "Successfully paused the speedtests"});
+});
+
+// Ends the pause-state
+app.post("/continue", (req, res) => {
+    pauseController.updateState(false);
+    res.json({message: "Successfully resumed the speedtests"});
 });
 
 // Get a specific speedtest

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -5,7 +5,11 @@ const axios = require('axios');
 
 
 app.get("/version", async (req, res) => {
-    res.json({local: version, remote: (await axios.get(remote_url)).data.version});
+    try {
+        res.json({local: version, remote: (await axios.get(remote_url)).data.version});
+    } catch (e) {
+        res.status(500).json({message: "An error occurred"});
+    }
 });
 
 module.exports = app;

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -1,8 +1,11 @@
 const app = require('express').Router();
 const version = require('../../package.json').version;
+const remote_url = "https://raw.githubusercontent.com/gnmyt/myspeed/release/package.json";
+const axios = require('axios');
 
-app.get("/version", (req, res) => {
-    res.send("MySpeed Server version " + version);
+
+app.get("/version", async (req, res) => {
+    res.json({local: version, remote: (await axios.get(remote_url)).data.version});
 });
 
 module.exports = app;

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -2,6 +2,7 @@ const app = require('express').Router();
 const version = require('../../package.json').version;
 const remote_url = "https://raw.githubusercontent.com/gnmyt/myspeed/release/package.json";
 const axios = require('axios');
+const fs = require("fs");
 
 
 app.get("/version", async (req, res) => {
@@ -10,6 +11,10 @@ app.get("/version", async (req, res) => {
     } catch (e) {
         res.status(500).json({message: "An error occurred"});
     }
+});
+
+app.get("/server", (req, res) => {
+    res.json(JSON.parse(fs.readFileSync("./data/servers.json").toString()));
 });
 
 module.exports = app;

--- a/server/tasks/loadServers.js
+++ b/server/tasks/loadServers.js
@@ -1,0 +1,24 @@
+const axios = require('axios');
+const fs = require('fs');
+
+if (!fs.existsSync("data/servers.json")) {
+    let servers = {};
+    try {
+        axios.get("https://www.speedtest.net/api/js/servers?limit=20")
+            .then(res => res.data)
+            .then(data => {
+                data.forEach(row => {
+                    servers[row.id] = row.name + " (" + row.distance + "km)";
+                });
+
+                try {
+                    fs.writeFileSync("data/servers.json", JSON.stringify(servers, null, 4));
+                } catch (e) {
+                    console.error("Could not save servers file")
+                }
+            });
+    } catch (e) {
+        console.error("Could not get servers");
+    }
+
+}

--- a/server/tasks/speedtest.js
+++ b/server/tasks/speedtest.js
@@ -10,7 +10,7 @@ function roundSpeed(bytes, elapsed) {
 }
 
 async function createRecommendations() {
-    let list = tests.list();
+    let list = tests.list().filter((entry) => !entry.error);
     if (list.length >= 10) {
         let avgNumbers = {ping: 0, down: 0, up: 0};
         for (let i = 0; i < 10; i++) {
@@ -37,7 +37,7 @@ module.exports.run = async () => {
     return speedtest;
 }
 
-module.exports.create = async () => {
+module.exports.create = async (type = "auto") => {
     if (isRunning) return 500;
 
     try {
@@ -45,11 +45,11 @@ module.exports.create = async () => {
         let ping = Math.round(test.ping.latency);
         let download = roundSpeed(test.download.bytes, test.download.elapsed);
         let upload = roundSpeed(test.upload.bytes, test.upload.elapsed);
-        let testResult = tests.create(ping, download, upload);
+        let testResult = tests.create(ping, download, upload, Math.round((test.download.elapsed + test.upload.elapsed)/1000), type);
         console.log(`Test #${testResult} was executed successfully. 🏓 ${ping} ⬇ ${download}️ ⬆ ${upload}️`);
         createRecommendations().then(() => "");
     } catch (e) {
-        let testResult = tests.create(-1, -1, -1);
+        let testResult = tests.create(-1, -1, -1, null, type, e.message);
         console.log(`Test #${testResult} was not executed successfully. Please try reconnecting to the internet or restarting the software.`);
     }
     isRunning = false;

--- a/server/tasks/speedtest.js
+++ b/server/tasks/speedtest.js
@@ -49,7 +49,7 @@ module.exports.create = async () => {
         console.log(`Test #${testResult} was executed successfully. 🏓 ${ping} ⬇ ${download}️ ⬆ ${upload}️`);
         createRecommendations().then(() => "");
     } catch (e) {
-        let testResult = tests.create(0, 0, 0);
+        let testResult = tests.create(-1, -1, -1);
         console.log(`Test #${testResult} was not executed successfully. Please try reconnecting to the internet or restarting the software.`);
     }
     isRunning = false;

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -3,11 +3,32 @@ const schedule = require('node-schedule');
 
 let job;
 
-module.exports.startTimer = () => {
-    const rule = new schedule.RecurrenceRule();
-    rule.minute = 0
+module.exports.startTimer = (timeLevel) => {
+    job = schedule.scheduleJob(getRuleFromLevel(timeLevel), () => this.runTask());
+}
 
-    job = schedule.scheduleJob(rule, () => this.runTask());
+const getRuleFromLevel = (level) => {
+    const rule = new schedule.RecurrenceRule();
+
+    switch (level) {
+        case 1:
+            rule.second = 0;
+            break;
+        case 2:
+            rule.minute = [0, 30]
+            break;
+        case 3:
+            rule.minute = 0;
+            break;
+        case 4:
+            rule.hour = [0, 3, 6, 9, 12, 15, 18, 21];
+            break;
+        case 5:
+            rule.hour = [0, 6, 12, 18];
+            break;
+    }
+
+    return rule;
 }
 
 module.exports.runTask = async () => {
@@ -20,7 +41,10 @@ module.exports.runTask = async () => {
 }
 
 module.exports.stopTimer = () => {
-    job.gracefulShutdown();
+    if (job !== undefined) {
+        job.cancel();
+        job = undefined;
+    }
 }
 
 module.exports.job = job;

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -10,20 +10,20 @@ module.exports.startTimer = (timeLevel) => {
 const getRuleFromLevel = (level) => {
     const rule = new schedule.RecurrenceRule();
 
-    switch (level) {
-        case 1:
+    switch (level.value) {
+        case "1":
             rule.second = 0;
             break;
-        case 2:
+        case "2":
             rule.minute = [0, 30]
             break;
-        case 3:
+        case "3":
             rule.minute = 0;
             break;
-        case 4:
+        case "4":
             rule.hour = [0, 3, 6, 9, 12, 15, 18, 21];
             break;
-        case 5:
+        case "5":
             rule.hour = [0, 6, 12, 18];
             break;
     }

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -10,7 +10,7 @@ module.exports.startTimer = (timeLevel) => {
 const getRuleFromLevel = (level) => {
     const rule = new schedule.RecurrenceRule();
 
-    switch (level.value) {
+    switch (level) {
         case "1":
             rule.second = 0;
             break;

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -1,0 +1,37 @@
+const pauseController = require('../controller/pause');
+
+let newDate = new Date();
+let timer;
+
+module.exports.startTimer = () => {
+    if (timer != null) this.stopTimer();
+
+    if (newDate.getMinutes() === 0) {
+        this.runTask();
+    } else {
+        newDate.setHours(newDate.getHours() + 1);
+        newDate.setMinutes(0);
+        newDate.setSeconds(0);
+    
+        var difference = newDate - new Date();
+        timer = setTimeout(this.runTask, difference);
+    }
+}
+
+module.exports.runTask = async () => {
+    if (pauseController.currentState) {
+        console.warn("Speedtests currently paused. Trying again later...");
+        return;
+    }
+
+    await require('../tasks/speedtest').create();
+}
+
+module.exports.stopTimer = () => {
+    if (timer != null)
+        clearTimeout(timer);
+    
+    timer = null;
+}
+
+module.exports.timer = timer;

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -16,7 +16,7 @@ module.exports.runTask = async () => {
         return;
     }
 
-    await require('../tasks/speedtest').create();
+    await require('../tasks/speedtest').create("auto");
 }
 
 module.exports.stopTimer = () => {

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -1,21 +1,13 @@
 const pauseController = require('../controller/pause');
+const schedule = require('node-schedule');
 
-let newDate = new Date();
-let timer;
+let job;
 
 module.exports.startTimer = () => {
-    if (timer != null) this.stopTimer();
+    const rule = new schedule.RecurrenceRule();
+    rule.minute = 0
 
-    if (newDate.getMinutes() === 0) {
-        this.runTask();
-    } else {
-        newDate.setHours(newDate.getHours() + 1);
-        newDate.setMinutes(0);
-        newDate.setSeconds(0);
-    
-        var difference = newDate - new Date();
-        timer = setTimeout(this.runTask, difference);
-    }
+    job = schedule.scheduleJob(rule, () => this.runTask());
 }
 
 module.exports.runTask = async () => {
@@ -28,10 +20,7 @@ module.exports.runTask = async () => {
 }
 
 module.exports.stopTimer = () => {
-    if (timer != null)
-        clearTimeout(timer);
-    
-    timer = null;
+    job.gracefulShutdown();
 }
 
-module.exports.timer = timer;
+module.exports.job = job;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Colors for better overview
+GREEN='\033[0;32m'
+BLUE='\033[1;34m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+NORMAL='\033[0;39m'
+
+INSTALLATION_PATH="/opt/myspeed"
+
+# Root check
+if [ $EUID -ne 0 ]; then
+  echo -e "$RED✗ Fehler bei der Deinstallation:$NORMAL Du benötigst Root-Rechte, um die Deinstallation zu starten."
+  exit
+fi
+
+echo -e "$GREEN ---------$BLUE Automatische Deinstallation$GREEN ---------"
+echo -e "$BLUE MySpeed$YELLOW wird nun deinstalliert."
+echo -e "$YELLOW Wenn du das$RED nicht$YELLOW möchtest, kannst du die"
+echo -e "$YELLOW Deinstallation mit$RED STRG + C$YELLOW abbrechen. "
+echo -e "$GREEN Die Deinstallation beginnt in 5 Sekunden..."
+echo -e "$GREEN ----------------------------------------------"
+sleep 5
+clear
+
+# remove system file
+if command -v systemctl &> /dev/null && systemctl --all --type service | grep -n "myspeed.service"; then
+  systemctl stop myspeed
+  systemctl disable myspeed
+  rm /etc/systemd/system/myspeed.service
+  rm /usr/lib/systemd/system/myspeed.service
+  systemctl daemon-reload
+  systemctl reset-failed
+fi
+
+# remove folder
+if [ "$1" == "--keep-data" ]; then
+  mv $INSTALLATION_PATH/data /tmp/myspeed_data
+  rm -R $INSTALLATION_PATH
+  mkdir /opt/myspeed
+  mv /tmp/myspeed_data $INSTALLATION_PATH/data
+else
+  rm -R $INSTALLATION_PATH
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,7 +22,10 @@ echo -e "$YELLOW Deinstallation mit$RED STRG + C$YELLOW abbrechen. "
 echo -e "$GREEN Die Deinstallation beginnt in 5 Sekunden..."
 echo -e "$GREEN ----------------------------------------------"
 sleep 5
+
 clear
+echo -e "$BLUE🔎 Status:$NORMAL Die Servicedaten werden entfernt, falls vorhanden..."
+sleep 3
 
 # remove system file
 if command -v systemctl &> /dev/null && systemctl --all --type service | grep -n "myspeed.service"; then
@@ -34,6 +37,10 @@ if command -v systemctl &> /dev/null && systemctl --all --type service | grep -n
   systemctl reset-failed
 fi
 
+clear
+echo -e "$BLUE🔎 Status:$NORMAL Die MySpeed-Systemdaten werden entfernt, falls vorhanden..."
+sleep 3
+
 # remove folder
 if [ "$1" == "--keep-data" ]; then
   mv $INSTALLATION_PATH/data /tmp/myspeed_data
@@ -43,3 +50,8 @@ if [ "$1" == "--keep-data" ]; then
 else
   rm -R $INSTALLATION_PATH
 fi
+
+clear
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
+echo -e "$GREEN✓ Fertig: $NORMAL MySpeed wurde deinstalliert."
+echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor


### PR DESCRIPTION
## 📣 Was ist neu? Die großen Änderungen
- ⏸️ Speedtests lassen sich nun pausieren (Idee von [Nils Stadelhoff](https://www.instagram.com/nils_filmstudio/))
- 🔔 Bei einem neuen Update wird nun eine Benachrichtigung angezeigt
- 🗃️ Du kannst deine Speedtests nun als .json und .csv Datei exportieren
- 🕒 Du kannst nun die Häufigkeit der Tests einstellen (Idee von @pavl21)

## 📣 Was ist neu? Die kleinen Änderungen
- Das Installationsskript wurde überarbeitet, vereinfacht und schöner gestaltet. (Danke an @pavl21 für die Hilfe!)
- Die Screenshots in der README wurden erneuert
- Speedtests starten nun standardmäßig immer bei einer neuen Stunde
- Die Anzeige bei Fehlern würde verschönert und Bugs wurden behoben
- Mit einem Klick auf die Uhr kannst du nun mehr Daten zu dem Test ansehen
- Es wurde eine Auswahlbox für die Server hinzugefügt

## ❗ Manuelles Update der Tabellen notwendig
Durch die neue Version wird nun vorausgesetzt, dass Sekunden, Fehler und Zeit in der Tabelle gespeichert werden können. Da diese Spalten in der alten Version nicht existieren, müssen diese manuell hinzugefügt werden.
Starte danach deine MySpeed-Instanz neu: `systemctl restart myspeed`

Hierbei hast du 2 Wege:
1. Lösche deine alten Daten. Dazu musst du einfach nur den `data`-Ordner aus deiner MySpeed-Instanz entfernen  
  `rm -rf /opt/myspeed/data`
2. Füge die Spalten manuell hinzu. Navigiere dazu in dein Installationsverzeichnis und füge den folgenden Befehl ein:  
  `node -e "const db = require('better-sqlite3')('data/storage.db'); db.exec('ALTER TABLE speedtests ADD error VARCHAR(255)'); db.exec('ALTER TABLE speedtests ADD type VARCHAR(255)'); db.exec('ALTER TABLE speedtests ADD time double');"`
  ⚠️ Es können Fehler bei älteren Tests auftreten, welche vor dem Update erstellt wurden.
3. Füge nun auch die neue "timeLevel"-Variable in die Konfiguration ein
  `node -e "db = require('better-sqlite3')('data/storage.db'); db.prepare('INSERT INTO config (key, value) VALUES (?, ?)').run('timeLevel', 3)"`