### PR TITLE
🧮 Logik für Versions-Deployments aktualisiert

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,6 +3,7 @@ name: Upload the latest release
 on:
   push:
     tags: [ "v*" ]
+    branches: [ "development" ]
 
 jobs:
   create:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,7 +2,7 @@ name: Upload the latest release
 
 on:
   push:
-    branches: [ release ]
+    tags: [ "v*" ]
 
 jobs:
   create:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.get_version.outputs.version }}
           prerelease: false
           title: Release ${{ steps.get_version.outputs.version }}
           files: |


### PR DESCRIPTION
# 📌 Wichtige Änderung im Release-Workflow

Mit dieser PR wird das System, wie neue Versionen entstehen, verändert.

# ❓ Was hat sich verändert?

Vorher war jedes Versionsupdate so aufgebaut, dass man alle Daten in den Branch `release` verschieben musste. Das hat aber immer zu unangenehmen Nebeneffekten geführt. Deswegen wird jetzt jedes Versionsupdate mit einem Tag gekennzeichnet. Erstellt man einen, erstellt der Workflow den dazugehörigen Release automatisch.

Wichtig zu beachten ist jedoch, dass dieser Tag immer mit einem v beginnen muss. Also z. B. v1.0.0 oder v1.2.0