### PR TITLE
🧮 Logik für Versions-Deployments aktualisiert [Bug-Fix]

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,7 +3,6 @@ name: Upload the latest release
 on:
   push:
     tags: [ "v*" ]
-    branches: [ "development" ]
 
 jobs:
   create:


### PR DESCRIPTION
# 🐛 Bug-Fix für die PR #22 
Durch eine Verwechslung in https://github.com/gnmyt/myspeed/pull/22/commits/34e17e889e86415070300d4762d31b81ce26b788 wurde der `development`-Branch als weiteres Event hinzugefügt (anstatt wie geplant als UND-Bedingung)

Ja ich weiß, hätte man sich denken können. Lasst mich 😅