### PR TITLE
🐛 Fehler in Funktion "Speedtests pausieren" behoben

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import TestAreaComponent from "./components/TestAreaComponent";
 import {ConfigProvider} from "./context/ConfigContext";
 import {DialogProvider} from "./context/DialogContext";
 import {SpeedtestProvider} from "./context/SpeedtestContext";
+import {StatusProvider} from "./context/StatusContext";
 
 function App() {
 
@@ -13,16 +14,18 @@ function App() {
             <SpeedtestProvider>
                 <DialogProvider>
                     <ConfigProvider>
+                        <StatusProvider>
 
-                        <HeaderComponent/>
-                        <main>
-                            <LatestTestComponent/>
+                            <HeaderComponent/>
+                            <main>
+                                <LatestTestComponent/>
 
-                            <hr/>
+                                <hr/>
 
-                            <TestAreaComponent/>
-                        </main>
+                                <TestAreaComponent/>
+                            </main>
 
+                        </StatusProvider>
                     </ConfigProvider>
                 </DialogProvider>
             </SpeedtestProvider>

--- a/client/src/components/LatestTestComponent.js
+++ b/client/src/components/LatestTestComponent.js
@@ -6,8 +6,10 @@ import {useContext, useEffect, useState} from "react";
 import {ConfigContext} from "../context/ConfigContext";
 import {DialogContext} from "../context/DialogContext";
 import {SpeedtestContext} from "../context/SpeedtestContext";
+import {StatusContext} from "../context/StatusContext";
 
 function LatestTestComponent() {
+    const status = useContext(StatusContext)[0];
     const [latest, setLatest] = useState({ping: "-", download: "-", upload: "-"});
     const [latestTestTime, setLatestTestTime] = useState("-");
     const [setDialog] = useContext(DialogContext);
@@ -27,7 +29,7 @@ function LatestTestComponent() {
     if (Object.entries(config).length === 0) return (<></>);
 
     return (
-        <div className="analyse-area pulse">
+        <div className={"analyse-area " + (status.paused ? "tests-paused" : "pulse")}>
             {/* Ping */}
             <div className="inner-container">
                 <div className="container-header">

--- a/client/src/context/StatusContext.js
+++ b/client/src/context/StatusContext.js
@@ -1,0 +1,27 @@
+import React, {useState, createContext, useEffect} from "react";
+
+export const StatusContext = createContext();
+
+export const StatusProvider = (props) => {
+
+    const [status, setStatus] = useState({paused: false});
+
+    const updateStatus = () => {
+        let headers = localStorage.getItem("password") ? {password: localStorage.getItem("password")} : {}
+        fetch("/api/speedtests/status", {headers})
+            .then(res => res.json())
+            .then(tests => setStatus(tests))
+    }
+
+    useEffect(() => {
+        updateStatus();
+        const interval = setInterval(() => updateStatus(), 15000);
+        return () => clearInterval(interval);
+    }, []);
+
+    return (
+        <StatusContext.Provider value={[status, updateStatus]}>
+            {props.children}
+        </StatusContext.Provider>
+    )
+}


### PR DESCRIPTION
# 🐛 Fehler in Funktion "Speedtests pausieren" behoben

Seit der neuen Version gab es den Fehler, dass in der UI beim Neuladen der Seite im pausierten Status die Farbe erst nach 15 Sekunden geändert wurde. Das lag daran, dass beim abrufen des Pausen-Status der Komponent für den letzten Test noch gar nicht gerendert war und so auch nicht aktualisiert werden konnte.

Das wurde nun behoben. Jetzt wird eine Pause wieder direkt am Start geladen und angezeigt
- Es wurde der `StatusContext` hinzugefügt
- Der `StatusContext` wurde sowohl in den `DropdownComponent` als auch in den `LatestTestComponent` integriert, um unabhängig zu funktionieren