### PR TITLE
🐛 Fehler mit CLI unter Windows behoben

### DIFF
--- a/server/config/loadCli.js
+++ b/server/config/loadCli.js
@@ -8,7 +8,7 @@ const binaries = require('./binaries');
 
 const binaryRegex = /speedtest(.exe)?$/;
 const binaryDirectory = __dirname + "/../../bin/";
-const binaryPath = `${binaryDirectory}/speedtest`;
+const binaryPath = `${binaryDirectory}/speedtest` + (process.platform === "win32" ? ".exe" : "");
 
 const downloadPath = `https://install.speedtest.net/app/cli/ookla-speedtest-${binaries.version}-`;
 
@@ -28,7 +28,7 @@ module.exports.downloadFile = async () => {
                         plugins: [decompressTarGz(), decompressUnzip()],
                         filter: file => binaryRegex.test(file.path),
                         map: file => {
-                            file.path = "speedtest";
+                            file.path = "speedtest" + (process.platform === "win32" ? ".exe" : "");
                             return file;
                         }
                     });

--- a/server/util/speedtest.js
+++ b/server/util/speedtest.js
@@ -1,6 +1,6 @@
 const {spawn} = require('child_process');
 
-module.exports = async (serverId, binary_path = './bin/speedtest') => {
+module.exports = async (serverId, binary_path = './bin/speedtest' + (process.platform === "win32" ? ".exe" : "")) => {
     const args = ['--accept-license', '--accept-gdpr', '--format=jsonl'];
     if (serverId) args.push(`--server-id=${serverId}`);
 


### PR DESCRIPTION
# 🐛 Fehler mit CLI unter Windows behoben

Mit dieser PR wird der Bug mit der Speedtest CLI unter Windows behoben. Zuvor hat das Programm immer versucht, die CLI ohne jegliche Dateinamenerweiterung herunterzuladen. Das mag Windows nicht. Deswegen wird jetzt immer ein ".exe" hinter den Namen der cli gesetzt, damit die Software auch unter Windows läuft 😅