### PR TITLE
🐛 Versionsfehler in der info route behoben

### DIFF
--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 
 app.get("/version", async (req, res) => {
     try {
-        res.json({local: version, remote: (await axios.get(remote_url)).data.tag_name});
+        res.json({local: version, remote: ((await axios.get(remote_url)).data.tag_name).replace("v", "")});
     } catch (e) {
         res.json({local: version, remote: "0"});
     }


### PR DESCRIPTION
# 🐛 Versionsfehler in der info route behoben

Warum?
MySpeed verwendet das [SemVer](https://semver.org/lang/de/) Format. Dadurch, dass in https://github.com/gnmyt/myspeed/commit/3fba2a7e7349a3ab2a2283e23c0261628a075adf die Tags von "1.0.0" auf "v1.0.0" geändert wurden, erkennt MySpeed jetzt alles als neue Version und gibt auch wenn man aktualisiert hat eine Update-Meldung aus. Das wurde jetzt behoben, indem das "v" in der Nachricht einfach entfernt wurde.