### PR TITLE
Installationsprozess informativer gemacht

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,10 @@ done
 
 # Root check
 if [ $EUID -ne 0 ]; then
-  echo -e "$RED✗ Fehler bei der Installation:$NORMAL Du benötigst Root-Rechte, um die Installation zu starten."
+  echo -e "$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-"
+  echo -e "$RED✗ ABGEBROCHEN"
+  echo -e "$NORMAL Die Installation läuft derzeit über einen Benutzer ohne Root-Rechte. Dies ist allerdings erforderlich. Melde dich mit einem Root Account an, um fortzufahren."
+  echo -e "$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-$RED-$NORMAL-"
   exit
 fi
 
@@ -34,25 +37,42 @@ echo -e "$YELLOW Ort:$BLUE $INSTALLATION_PATH"
 echo -e "$YELLOW Es wird die Speedtest API von Ookla verwendet."
 echo -e "$YELLOW Wenn du damit$RED nicht$YELLOW einverstanden bist,"
 echo -e "$YELLOW kannst du die Installation mit$RED STRG + C$YELLOW abbrechen. "
-echo -e "$GREEN Die Installation beginnt in 5 Sekunden..."
+echo -e "$GREEN Die Installation beginnt in 10 Sekunden..."
 echo -e "$GREEN ----------------------------------------------"
-sleep 5
+sleep 10
 clear
 
 # Check if installed
 if [ -d "$INSTALLATION_PATH" ]; then
-    echo -e "$YELLOW⚠ Warnung: $NORMAL MySpeed ist bereits auf diesem System installiert."
-    echo -e "$GREENℹ Info:$NORMAL Es wird nun der aktuelle Release installiert..."
+    clear
+    echo -e "$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-"
+    echo -e ""
+    echo -e "$YELLOW⚠ WARNUNG"
+    echo -e "$NORMAL MySpeed ist bereits auf diesem System installiert."
+    echo -e ""
+    echo -e "$GREENℹ Info:$NORMAL Neuestes Update wird installiert..."
+    echo -e ""
+    echo -e "$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-$YELLOW-$NORMAL-"
     sleep 5
 fi
 
 if command -v systemctl &> /dev/null && systemctl --all --type service | grep -n "myspeed.service"; then
+  clear
+  echo -e "$YELLOWℹ MySpeed Dienst wird gestoppt..."
   systemctl stop myspeed
 fi
 
 
 # Update all packages
-echo -e "$BLUE🔎 Status:$NORMAL Es wird nach neuen Updates für das Linux-System gesucht..."
+clear
+echo -e ""
+echo -e "$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-"
+echo -e ""
+echo -e "$BLUE🔎 STATUSMELDUNG"
+echo -e "$NORMAL Update-Suche für Linux-System gestartet..."
+echo -e ""
+echo -e "$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-"
+echo -e ""
 apt-get update -y
 
 clear
@@ -61,11 +81,16 @@ sleep 5
 
 function check() {
   clear
-  echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob $1 vorhanden ist..."
+  echo -e "$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-"
+  echo -e "$BLUE🔎 STATUSMELDUNG"
+  echo -e "$NORMAL Es wird überprüft, ob $1 vorhanden ist..."
+  echo -e "$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-$BLUE-$NORMAL-"
+  echo -e ""
   if ! command -v "$1" &> /dev/null
   then
-      echo -e "$YELLOWℹ \"$1\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+      echo -e "$YELLOWℹ \"$1\" ist nicht installiert.$NORMAL Die Installation wird gestartet..."
       sleep 2
+      echo -e "$PURPLEℹ Wird installiert..."
       apt-get install "$1" -y
   fi
 }
@@ -76,12 +101,17 @@ check "curl"
 
 # Check for node
 clear
-echo -e "$BLUE🔎 Status:$NORMAL Überprüfe, ob node vorhanden ist..."
+echo -e "$BLUE🔎 STATUSMELDUNG"
+echo -e "$NORMAL Es wird überprüft, ob node vorhanden ist..."
 if ! command -v node &> /dev/null
 then
-    echo -e "$YELLOWℹ \"node\" ist nicht installiert.$NORMAL Die Installation wurde gestartet..."
+    echo -e "$YELLOWℹ \"node\" ist nicht installiert.$NORMAL Die Installation wird gestartet..."
     sleep 2
+    clear
+    echo -e "$PURPLEℹ Wird heruntergeladen..."
     curl -sSL https://deb.nodesource.com/setup_16.x | bash
+    clear
+    echo -e "$PURPLEℹ Wird installiert..."
     apt-get install nodejs -y
 fi
 
@@ -100,6 +130,7 @@ sleep 3
 clear
 if [ ! -d "$INSTALLATION_PATH" ]
 then
+    clear
     echo -e "$BLUEℹ Info: $NORMAL MySpeed wird unter dem Verzeichnis $INSTALLATION_PATH installiert. Der Ordner wird nun erstellt."
     sleep 2
     mkdir "$INSTALLATION_PATH"
@@ -107,6 +138,7 @@ fi
 
 cd "$INSTALLATION_PATH"
 
+clear
 echo -e "$BLUEℹ Info: $NORMAL Die aktuelle MySpeed-Instanz wird heruntergeladen. Einen Moment..."
 sleep 2
 wget "$RELEASE_URL"
@@ -125,12 +157,14 @@ else
 fi
 
 
+clear
 echo -e "$BLUEℹ Info: $NORMAL Die notwendigen Abhängigkeiten werden jetzt installiert..."
 sleep 2
 rm -rf "$INSTALLATION_PATH/node_modules"
 npm install --force
 
 if [ "$1" == "--beta" ]; then
+  clear
   echo -e "$BLUEℹ Info: $NORMAL Die Weboberfläche wird kompiliert..."
   sleep 2
   cd client && npm install --force
@@ -141,7 +175,11 @@ fi
 
 # Install as system service
 clear
-echo -e "$BLUE🔎 Status:$NORMAL Registriere MySpeed als Hintergrunddienst..."
+echo -e "$BLUE🔎 STATUSMELDUNG"
+echo -e "$NORMAL Registriere MySpeed als Hintergrunddienst..."
+echo -e ""
+echo -e ""
+sleep 2
 if command -v systemctl &> /dev/null && ! systemctl --all --type service | grep -n "myspeed.service"; then
   cat << EOF >> /etc/systemd/system/myspeed.service
   [Unit]
@@ -160,7 +198,11 @@ if command -v systemctl &> /dev/null && ! systemctl --all --type service | grep 
   WantedBy=multi-user.target
 EOF
   systemctl daemon-reload
+  echo -e "$NORMALℹ MySpeed wird im Autostart hinzugefügt..."
+  sleep 1
   systemctl enable myspeed
+  echo -e "$NORMALℹ MySpeed Dienst wird gestartet..."
+  sleep 1
   systemctl start myspeed
 fi
 
@@ -171,9 +213,12 @@ if ! command -v systemctl &> /dev/null; then
     echo -e "$BLUEℹ Info: $NORMAL Du kannst, wenn du \"systemd\" installiert hast, die Installation erneut starten. Es wird dann automatisch eingestellt."
     sleep 5
 else
+  echo -e "$GREENℹ MySpeed wird neu gestartet..."
+  sleep 2
   systemctl restart myspeed
 fi
 
+clear
 echo -e "$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-$GREEN-$NORMAL-" #multicolor
 echo -e "$GREEN✓ Installation abgeschlossen: $NORMAL MySpeed wurde unter $INSTALLATION_PATH installiert."
 echo -e "Die Weboberfläche findest du im Browser unter$BLUE http://$(curl -s ifconfig.me):5216$NORMAL."


### PR DESCRIPTION
# 📑 Installationsprozess informativer gemacht

Auch kleinere Schritte, wie das Herunterladen und auch installieren eines Paketes, wird jetzt wiedergegeben. Zudem wurde es Anhand der Optik vom Start und vom Abschluss angepasst, sodass auch bei Fehlermeldungen oder Statusänderungen diese Optik angenommen wird. Einige Prozesse werden jetzt auch für 1 bis 2 Sekunden pausiert, damit man es kurz "vorbeilaufen" sieht (sollte das Linux System gar nicht die Möglichkeit geben, es zu zeigen). Einige Texte wurden erneut überarbeitet. Beim Start der Installation wurde der Countdown auf 10 Sekunden erhöht, damit man sich den Hinweis besser durchlesen kann.


## Änderungen vorgenommen an ...

- [ ] Server
- [ ] Client
- [ ] Dokumentation
- [x] Sonstiges: Installationsprozess