### PR TITLE
🐛 Bug mit leerem Input behoben

### DIFF
--- a/client/src/common/contexts/Dialog/DialogContext.jsx
+++ b/client/src/common/contexts/Dialog/DialogContext.jsx
@@ -42,6 +42,7 @@ const Dialog = ({dialog, setDialog}) => {
     }
 
     function submit() {
+        if (!dialog.description && !value) return;
         setDialog();
         hideTooltips(false);
         if (dialog.onSuccess) dialog.onSuccess(value);


### PR DESCRIPTION
# 🐛 Bug mit leerem Input behoben

Es wurde ein Bug behoben, mit welchem es möglich war, leere Werte abzusenden. Möglich war das beispielsweise beim Pausieren ohne einen Wert einzugeben. Genauere Infos zum Bug in #36

## Änderungen vorgenommen an ...

- [ ] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___