### PR TITLE
⏰ Umstieg auf Cron-Ausdrücke

### DIFF
--- a/client/src/common/components/Dropdown/DropdownComponent.jsx
+++ b/client/src/common/components/Dropdown/DropdownComponent.jsx
@@ -218,22 +218,22 @@ function DropdownComponent() {
         });
     }
 
-    const updateLevel = async () => {
+    const updateCron = async () => {
         toggleDropdown();
         setDialog({
             title: "Test-Häufigkeit einstellen",
             select: true,
             selectOptions: {
-                1: "Durchgehend (jede Minute)",
-                2: "Sehr häufig (alle 30 Minuten)",
-                3: "Standard (jede Stunde)",
-                4: "Selten (alle 3 Stunden)",
-                5: "Sehr selten (alle 6 Stunden)"
+                "* * * * *": "Durchgehend (jede Minute)",
+                "0,30 * * * *": "Sehr häufig (alle 30 Minuten)",
+                "0 * * * *": "Standard (jede Stunde)",
+                "0 0,3,6,9,12,15,18,21 * * *": "Selten (alle 3 Stunden)",
+                "0 0,6,12,18 * * *": "Sehr selten (alle 6 Stunden)"
             },
-            value: config.timeLevel,
+            value: config.cron,
             onSuccess: value => {
-                fetch("/api/config/timeLevel", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
-                    .then(() => showFeedback(undefined, false));
+                fetch("/api/config/cron", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
+                    .then(() => showFeedback());
             }
         });
     }
@@ -309,7 +309,7 @@ function DropdownComponent() {
                         <FontAwesomeIcon icon={faKey}/>
                         <h3>Passwort ändern</h3>
                     </div>
-                    <div className="dropdown-item" onClick={updateLevel}>
+                    <div className="dropdown-item" onClick={updateCron}>
                         <FontAwesomeIcon icon={faClock}/>
                         <h3>Häufigkeit einstellen</h3>
                     </div>

--- a/client/src/common/components/Dropdown/DropdownComponent.jsx
+++ b/client/src/common/components/Dropdown/DropdownComponent.jsx
@@ -61,7 +61,7 @@ function DropdownComponent() {
             ...dialog(config[key]),
             onSuccess: value => {
                 fetch("/api/config/" + key, {headers, method: "PATCH", body: JSON.stringify({value})})
-                    .then(() => showFeedback());
+                    .then(res => showFeedback(!res.ok ? "Deine Änderungen wurden nicht übernommen. Überprüfe deine Eingabe." : undefined));
             }
         })
     }

--- a/client/src/common/components/Dropdown/DropdownComponent.jsx
+++ b/client/src/common/components/Dropdown/DropdownComponent.jsx
@@ -218,6 +218,10 @@ function DropdownComponent() {
         });
     }
 
+    const updateCronManually = () => patchDialog("cron", (value) => ({
+        title: <>Test-Häufigkeit einstellen <a href="https://crontab.guru/" target="_blank">?</a></>, placeholder: "Cron-Regel", value: value,
+    }), false);
+
     const updateCron = async () => {
         toggleDropdown();
         setDialog({
@@ -231,6 +235,9 @@ function DropdownComponent() {
                 "0 0,6,12,18 * * *": "Sehr selten (alle 6 Stunden)"
             },
             value: config.cron,
+            unsetButton: true,
+            unsetButtonText: "Manuell festlegen",
+            onClear: updateCronManually,
             onSuccess: value => {
                 fetch("/api/config/cron", {headers: headers, method: "PATCH", body: JSON.stringify({value: value})})
                     .then(() => showFeedback());

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "bcrypt": "^5.0.1",
+        "cron-validator": "^1.3.1",
         "decompress": "^4.2.1",
         "decompress-targz": "^4.1.1",
         "decompress-unzip": "^4.0.1",
@@ -802,6 +803,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "node_modules/date-fns": {
       "version": "2.28.0",
@@ -3780,6 +3786,11 @@
         "is-nan": "^1.3.2",
         "luxon": "^1.26.0"
       }
+    },
+    "cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "date-fns": {
       "version": "2.28.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
+    "cron-validator": "^1.3.1",
     "decompress": "^4.2.1",
     "decompress-targz": "^4.1.1",
     "decompress-unzip": "^4.0.1",

--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -4,7 +4,7 @@ const configDefaults = {
     "ping": "25",
     "download": "100",
     "upload": "50",
-    "timeLevel": "3",
+    "cron": "0 * * * *",
     "serverId": "none",
     "password": "none",
     "healthChecksUrl": "https://hc-ping.com/<uuid>"

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ const run = async () => {
     await config.insertDefaults();
 
     // Start all timer
-    timerTask.startTimer((await config.get("timeLevel")).value);
+    timerTask.startTimer((await config.get("cron")).value);
     setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
 
     // Start Healthchecks

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -1,6 +1,7 @@
 const app = require('express').Router();
 const config = require('../controller/config');
 const timer = require('../tasks/timer');
+const cron = require('cron-validator');
 
 // Gets all config entries
 app.get("/", async (req, res) => {
@@ -32,11 +33,14 @@ app.patch("/:key", async (req, res) => {
 
     if (req.params.key === "password" && req.body.value !== "none") req.body.value = await require('bcrypt').hash(req.body.value, 10);
 
+    if (req.params.key === "cron" && !cron.isValidCron(req.body.value.toString()))
+        return res.status(500).json({message: "Not a valid cron expression"});
+
     if (!await config.update(req.params.key, req.body.value)) return res.status(404).json({message: "The provided key does not exist"});
 
-    if (req.params.key === "timeLevel") {
+    if (req.params.key === "cron") {
         timer.stopTimer();
-        timer.startTimer(req.body.value);
+        timer.startTimer(req.body.value.toString());
     }
 
     res.json({message: `The key '${req.params.key}' has been successfully updated`});

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -25,7 +25,7 @@ app.get("/:key", async (req, res) => {
 app.patch("/:key", async (req, res) => {
     if (!req.body.value) return res.status(400).json({message: "You need to provide the new value"});
 
-    if ((req.params.key === "ping" || req.params.key === "download" || req.params.key === "upload" || req.params.key === "timeLevel") && isNaN(req.body.value))
+    if ((req.params.key === "ping" || req.params.key === "download" || req.params.key === "upload") && isNaN(req.body.value))
         return res.status(400).json({message: "You need to provide a number in order to change this"});
 
     if (req.params.key === "ping")

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -1,10 +1,12 @@
 const pauseController = require('../controller/pause');
 const schedule = require('node-schedule');
+const {isValidCron} = require("cron-validator");
 
 let job;
 
-module.exports.startTimer = (timeLevel) => {
-    job = schedule.scheduleJob(getRuleFromLevel(timeLevel), () => this.runTask());
+module.exports.startTimer = (cron) => {
+    if (!isValidCron(cron)) return;
+    job = schedule.scheduleJob(cron, () => this.runTask());
 }
 
 module.exports.runTask = async () => {

--- a/server/tasks/timer.js
+++ b/server/tasks/timer.js
@@ -7,30 +7,6 @@ module.exports.startTimer = (timeLevel) => {
     job = schedule.scheduleJob(getRuleFromLevel(timeLevel), () => this.runTask());
 }
 
-const getRuleFromLevel = (level) => {
-    const rule = new schedule.RecurrenceRule();
-
-    switch (level) {
-        case "1":
-            rule.second = 0;
-            break;
-        case "2":
-            rule.minute = [0, 30]
-            break;
-        case "4":
-            rule.hour = [0, 3, 6, 9, 12, 15, 18, 21];
-            break;
-        case "5":
-            rule.hour = [0, 6, 12, 18];
-            break;
-        default:
-            rule.minute = 0;
-            break;
-    }
-
-    return rule;
-}
-
 module.exports.runTask = async () => {
     if (pauseController.currentState) {
         console.warn("Speedtests currently paused. Trying again later...");

--- a/server/util/speedtest.js
+++ b/server/util/speedtest.js
@@ -21,7 +21,13 @@ module.exports = async (serverId, binary_path = './bin/speedtest' + (process.pla
         const line = buffer.toString().replace("\n", "");
         if (!line.startsWith("{")) return;
 
-        let data = JSON.parse(line);
+        let data;
+        try {
+            data = JSON.parse(line);
+        } catch (e) {
+            data.error = e.message;
+        }
+
         if (data.error) result.error = data.error;
 
         if (data.type === "result") result = data;


### PR DESCRIPTION
# ⏰ Umstieg auf Cron-Ausdrücke

Anstatt von vorgefertigten Regeln Speedtests zu erstellen lassen sich die Zeiten der Speedtests nun 100% selbst bestimmen.
Es wurde im Menüpunkt "Häufigkeiten einstellen" ein Knopf hinzugefügt, um sich seinen eigenen Cron-Job zu konfigurieren.

Für diejenigen, die sich jedoch damit nicht auseinandersetzen möchten gibt es auch vorgefertigte Konfigurationen:
`* * * * *` -> Durchgehend (jede Minute)
`0,30 * * * *` -> Sehr häufig (alle 30 Minuten)
`0 * * * *` -> Standard (jede Stunde)
`0 0,3,6,9,12,15,18,21 * * *` -> Selten (alle 3 Stunden)
`0 0,6,12,18 * * *` -> Sehr selten (alle 6 Stunden)

Für eine Hilfe zu Cron-Ausdrücken lohnt es sich, mal einen Blick auf [Crontab Guru](https://crontab.guru/) zu werfen :)

## Änderungen vorgenommen an ...

- [x] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___