### PR TITLE
📜 Einführung der Fehler-Logs

### DIFF
--- a/server/config/createFolder.js
+++ b/server/config/createFolder.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const neededFolder = ["data", "bin"];
+const neededFolder = ["data", "bin", "data/logs"];
 
 neededFolder.forEach(folder => {
     if (!fs.existsSync(folder)) {

--- a/server/config/errorHandler.js
+++ b/server/config/errorHandler.js
@@ -4,11 +4,11 @@ const filePath = process.cwd() + "/data/logs/error.log";
 // Writes the errors into the error.log file
 module.exports = (error) => {
     const date = new Date().toLocaleString();
-    const lineStarter = fs.existsSync(filePath) ? "\n\n" : "";
+    const lineStarter = fs.existsSync(filePath) ? "\n\n" : "# Found a bug? Report it here: https://github.com/gnmyt/myspeed/issues\n\n";
 
     fs.writeFile(filePath, lineStarter + "## " + date + "\n" + error, {flag: 'a+'}, err => {
         if (err) console.error("Could not save error log file.", error);
-    });
 
-    process.exit(1);
+        process.exit(1);
+    });
 }

--- a/server/config/errorHandler.js
+++ b/server/config/errorHandler.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const filePath = process.cwd() + "/data/logs/error.log";
+
+// Writes the errors into the error.log file
+module.exports = (error) => {
+    const date = new Date().toLocaleString();
+    const lineStarter = fs.existsSync(filePath) ? "\n\n" : "";
+
+    fs.writeFile(filePath, lineStarter + "## " + date + "\n" + error, {flag: 'a+'}, err => {
+        if (err) console.error("Could not save error log file.", error);
+    });
+
+    process.exit(1);
+}

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ const port = process.env.port || 5216;
 require('./config/createFolder');
 require('./config/loadServers');
 
+process.on('uncaughtException', err => require('./config/errorHandler')(err));
+
 // Register middlewares
 app.use(express.json());
 app.use("/api/*", require('./middlewares/password'));


### PR DESCRIPTION
# 📜 Einführung der Fehler-Logs

Wie in #41 beschrieben werden nun Fehler-Nachrichten in einer seperaten Datei (`/data/logs/error.log`) gesichert um das melden von Bugs zu vereinfachen.
Natürlich hoffe ich, dass es nie zu solchen Fehlern kommt aber wenn es dann doch mal passiert ist diese Datei sehr hilfreich.

## Änderungen vorgenommen an ...

- [x] Server
- [ ] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___