### PR TITLE
📑 Wiki-Seite "Konfiguration eines Reverse-Proxies" hinzugefügt

### DIFF
--- a/docs/guides/reverse-proxy.md
+++ b/docs/guides/reverse-proxy.md
@@ -31,8 +31,8 @@ welchen Reverse Proxy du verwendet hast.
     Füge nun folgenden Inhalt in die Datei ein:
     ```nginx
     server {
-        listen 80; # Support for IPv4
-        listen [::]:80; # Support for IPv6
+        listen 80;
+        listen [::]:80;
 
         server_name deine-domain.de;
 

--- a/docs/guides/reverse-proxy.md
+++ b/docs/guides/reverse-proxy.md
@@ -1,0 +1,103 @@
+In diesem Guide wird erklärt, wie du mithilfe von `apache` oder `nginx` einen Reverse Proxy mit MySpeed einrichtest.
+
+!!! tip "Warum einen Reverse Proxy verwenden?"
+    In diesem Fall verwenden wir einen Reverse Proxy als Zwischenschicht zwischen dir und MySpeed.
+    Dies hat den Vorteil, dass du MySpeed nicht über einen Port aufrufen musst, sondern über eine normale Domain.
+
+## Installation
+Solltest du bereits einen Reverse Proxy installiert haben, kannst du diesen Schritt überspringen. Welchen der beiden
+Reverse Proxies du verwenden möchtest, ist dir überlassen. Wir empfehlen dir jedoch für diesen Guide `nginx`.
+
+=== "nginx"
+    ```sh
+    sudo apt-get install nginx -y
+    ```
+
+=== "apache"
+    ```sh
+    sudo apt-get install apache2 -y
+    ```
+
+## Konfiguration von MySpeed
+
+In diesem Abschnitt wird erklärt, wie du MySpeed mit deinem Reverse Proxy verbindest. Wähle hier auch wieder aus, 
+welchen Reverse Proxy du verwendet hast.
+
+=== "nginx"
+    Erstelle nun eine Datei mit dem Namen `myspeed.conf` unter `/etc/nginx/sites-available`. Hier verwenden wir `nano`
+    ```sh
+    sudo nano /etc/nginx/sites-available/myspeed.conf
+    ```
+    Füge nun folgenden Inhalt in die Datei ein:
+    ```nginx
+    server {
+        listen 80; # Support for IPv4
+        listen [::]:80; # Support for IPv6
+
+        server_name deine-domain.de;
+
+        location / {
+            proxy_pass http://localhost:5216;
+        }
+    }
+    ```
+    Nun musst du nur noch die Datei aktivieren und den Reverse Proxy neustarten.
+    ```sh
+    sudo ln -s /etc/nginx/sites-available/myspeed.conf /etc/nginx/sites-enabled/myspeed.conf
+    sudo systemctl restart nginx
+    ```
+
+=== "apache"
+    Erstelle nun eine Datei mit dem Namen `myspeed.conf` unter `/etc/apache2/sites-available`. Hier verwenden wir `nano`
+    ```sh
+    sudo nano /etc/apache2/sites-available/myspeed.conf
+    ```
+    Füge nun folgenden Inhalt in die Datei ein:
+    ```apache
+    <VirtualHost *:80>
+        ServerName deine-domain.de
+
+        ProxyPreserveHost On
+        ProxyPass / http://localhost:5216/
+        ProxyPassReverse / http://localhost:5216/
+    </VirtualHost>
+    ```
+    Aktiviere nun die `mod_proxy` und `mod_proxy_http` Module.
+    ```sh
+    sudo a2enmod proxy
+    sudo a2enmod proxy_http
+    ```
+    Nun musst du nur noch die Datei aktivieren und den Reverse Proxy neustarten.
+    ```sh
+    sudo a2ensite myspeed.conf
+    sudo systemctl restart apache2
+    ```
+
+## Konfiguration eines SSL Zertifikats mit Let's Encrypt
+
+In diesem Abschnitt wird erklärt, wie du ein SSL Zertifikat von Let's Encrypt für MySpeed einrichtest.
+
+!!! tip "Verwendest du Cloudflare?"
+    Wenn du Cloudflare verwendest und nicht extra ein SSL Zertifikat von Let's Encrypt einrichten möchtest, kannst du
+    auch einfach die Cloudflare Proxy Funktion aktivieren. Das genügt in den meisten Fällen vollkommen. Wenn du
+    dich für diese Variante entscheidest, kannst du diesen Abschnitt überspringen.
+
+=== "nginx"
+    Zuerst musst du Certbot installieren. Hierfür verwenden wir `apt`.
+    ```sh
+    sudo apt-get install certbot python3-certbot-nginx -y
+    ```
+    Nun musst du Certbot ausführen und die Domain angeben, für die du das Zertifikat einrichten möchtest.
+    ```sh
+    sudo certbot --nginx -d deine-domain.de
+    ```
+
+=== "apache"
+    Zuerst musst du Certbot installieren. Hierfür verwenden wir `apt`.
+    ```sh
+    sudo apt-get install certbot python3-certbot-apache -y
+    ```
+    Nun musst du Certbot ausführen und die Domain angeben, für die du das Zertifikat einrichten möchtest.
+    ```sh
+    sudo certbot --apache -d deine-domain.de
+    ```

--- a/docs/guides/reverse-proxy.md
+++ b/docs/guides/reverse-proxy.md
@@ -80,7 +80,7 @@ In diesem Abschnitt wird erklärt, wie du ein SSL Zertifikat von Let's Encrypt f
 !!! tip "Verwendest du Cloudflare?"
     Wenn du Cloudflare verwendest und nicht extra ein SSL Zertifikat von Let's Encrypt einrichten möchtest, kannst du
     auch einfach die Cloudflare Proxy Funktion aktivieren. Das genügt in den meisten Fällen vollkommen. Wenn du
-    dich für diese Variante entscheidest, kannst du diesen Abschnitt überspringen.
+    dich für den Cloudflare Proxy entscheidest, kannst du diesen Abschnitt überspringen.
 
 === "nginx"
     Zuerst musst du Certbot installieren. Hierfür verwenden wir `apt`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ nav:
   - Einrichtung:
       - Linux: setup/linux.md
       - Windows: setup/windows.md
+  - Guides:
+      - Konfiguration eines Reverse-Proxies: guides/reverse-proxy.md
   - Fehlerbehebung: troubleshooting.md
   - Handhabung:
       - Die Oberfläche: instructions/main.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MySpeed Dokumentation
-copyright: Copyright &copy; 2021 - 2022 Mathias Wagner
+copyright: Copyright &copy; 2021 - 2023 Mathias Wagner
 
 repo_name: MySpeed
 repo_url: https://github.com/gnmyt/myspeed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
   features:
     - toc.integrate
     - content.code.annotate
+    - content.code.copy
   favicon: assets/images/logo.png
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
# 📑 Wiki-Seite "Konfiguration eines Reverse-Proxies" hinzugefügt

Auf Wunsch von @pavl21 aus #235 wurde der Dokumentation eine Seite für die Installation eines Reverse Proxies (mit SSL Zertifikat) hinzugefügt.

## Änderungen vorgenommen an ...

- [ ] Server
- [ ] Client
- [x] Dokumentation
- [ ] Sonstiges: ___