### PR TITLE
🌐 Automatisches setzen der Browser-Sprache

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#232835" />
     <meta property="og:image" content="/logo.png" />
     <meta name="description"
-          content="Eine deutschsprachige Speedtest Analyse-Software, welche das Internet der letzten 24 Stunden übersichtlich darstellt."
+          content="A speed test analysis software that shows your internet speed for up to 30 days"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "MySpeed",
   "name": "MySpeed - Speedtests",
-  "description": "Eine deutschsprachige Speedtest Analyse-Software, welche das Internet der letzten 24 Stunden übersichtlich darstellt.",
+  "description": "A speed test analysis software that shows your internet speed for up to 30 days",
   "icons": [
     {
       "src": "favicon.ico",

--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -3,6 +3,9 @@ import {initReactI18next} from "react-i18next";
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi from 'i18next-http-backend';
 
+if (localStorage.getItem('language') === null)
+    localStorage.setItem('language', navigator.language.split('-')[0]);
+
 i18n.use(initReactI18next).use(LanguageDetector).use(HttpApi).init({
     supportedLngs: ['en', 'de'],
     fallbackLng: 'en',

--- a/client/src/i18n.js
+++ b/client/src/i18n.js
@@ -10,7 +10,7 @@ i18n.use(initReactI18next).use(LanguageDetector).use(HttpApi).init({
         loadPath: '/locales/{{lng}}.json'
     },
     detection: {
-        order: ['localStorage', 'htmlTag'],
+        order: ['localStorage'],
         lookupLocalStorage: 'language'
     }
 });


### PR DESCRIPTION
# 🌐 Automatisches setzen der Browser-Sprache

### 2 Änderungen wurden vorgenommen:
1. Die Sprache der Beschreibung innerhalb der `manifest.json` und den `Meta-Tags` ist nun Englisch.
2. MySpeed setzt nun automatisch die Sprache auf die des Browsers. Sollte die Sprache nicht unterstützt sein wird als Fallback-Sprache Englisch verwendet.

## Änderungen vorgenommen an ...

- [ ] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___