### PR TITLE
🐛 Übersetzungs-Bug behoben

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -44,17 +44,17 @@ const App = () => {
             {!translationError && translationsLoaded && <InputDialogProvider>
                 <ToastNotificationProvider>
                     <ConfigProvider showNodePage={setShowNodePage}>
-                    <NodeProvider>
-                        {showNodePage && <Nodes setShowNodePage={setShowNodePage}/>}
-                        {!showNodePage && <SpeedtestProvider>
-                            <ViewProvider>
+                        <NodeProvider>
+                            {showNodePage && <Nodes setShowNodePage={setShowNodePage}/>}
+                            {!showNodePage && <SpeedtestProvider>
+                                <ViewProvider>
                                     <StatusProvider>
                                         <HeaderComponent showNodePage={setShowNodePage}/>
                                         <MainContent/>
                                     </StatusProvider>
-                            </ViewProvider>
-                        </SpeedtestProvider>}
-                    </NodeProvider>
+                                </ViewProvider>
+                            </SpeedtestProvider>}
+                        </NodeProvider>
                     </ConfigProvider>
                 </ToastNotificationProvider>
             </InputDialogProvider>}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,13 +41,12 @@ const App = () => {
         <>
             {!translationsLoaded && !translationError && <Loading/>}
             {translationError && <Error text="Failed to load translations"/>}
-            <InputDialogProvider>
+            {!translationError && translationsLoaded && <InputDialogProvider>
                 <ToastNotificationProvider>
                     <ConfigProvider showNodePage={setShowNodePage}>
                     <NodeProvider>
-                        {translationsLoaded && !translationError && showNodePage &&
-                            <Nodes setShowNodePage={setShowNodePage}/>}
-                        {translationsLoaded && !translationError && !showNodePage && <SpeedtestProvider>
+                        {showNodePage && <Nodes setShowNodePage={setShowNodePage}/>}
+                        {!showNodePage && <SpeedtestProvider>
                             <ViewProvider>
                                     <StatusProvider>
                                         <HeaderComponent showNodePage={setShowNodePage}/>
@@ -58,7 +57,7 @@ const App = () => {
                     </NodeProvider>
                     </ConfigProvider>
                 </ToastNotificationProvider>
-            </InputDialogProvider>
+            </InputDialogProvider>}
         </>
     );
 }


### PR DESCRIPTION
# 🐛 Übersetzungs-Bug behoben

Im Falle eines Ausfalls des MySpeed-Servers sollte eine Fehlermeldung angezeigt werden, welche zeigt, dass die API nicht verfügbar ist. Diese wird aber wie im Bild unten nicht korrekt angezeigt, da auch die Übersetzungen nicht geladen werden können.

![Screenshot](https://user-images.githubusercontent.com/35641351/236860450-c4d74b4d-6034-4db7-8f35-33e83fe8db57.png)

Jetzt wird der Dialog nicht mehr angezeigt. Alles ab dem `InputDialogProvider` setzt nun voraus, dass alle Übersetzungen geladen wurden und dabei keine Fehler aufgetreten sind.

## Änderungen vorgenommen an ...

- [ ] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___