### PR TITLE
🐛 Neustart triggert neuen Speedtest

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,17 +9,14 @@ app.disable('x-powered-by');
 
 const port = process.env.port || 5216;
 
-// Create the data folder and the servers file
 require('./util/createFolders');
 require('./util/loadServers');
 
 process.on('uncaughtException', err => require('./util/errorHandler')(err));
 
-// Register middlewares
 app.use(express.json());
 app.use(require('./middlewares/error'));
 
-// Register routes
 app.use("/api/config", require('./routes/config'));
 app.use("/api/speedtests", require('./routes/speedtests'));
 app.use("/api/info", require('./routes/system'));
@@ -29,7 +26,6 @@ app.use("/api/nodes", require('./routes/nodes'));
 app.use("/api/integrations", require('./routes/integrations'));
 app.use("/api*", (req, res) => res.status(404).json({message: "Route not found"}));
 
-// Enable production
 if (process.env.NODE_ENV === 'production') {
     app.use(express.static(path.join(__dirname, '../build')));
 
@@ -38,32 +34,26 @@ if (process.env.NODE_ENV === 'production') {
     app.get("*", (req, res) => res.status(500).sendFile(path.join(__dirname, 'templates', 'env.html')));
 }
 
-// Connect to the database
 let db = require("./config/database");
 
 const run = async () => {
     const config = require('./controller/config');
 
-    // Sync the database
     await db.sync({alter: true, force: false});
 
-    // Load the integrations
     await require('./controller/integrations').initialize();
 
-    // Load the cli
     await require('./util/loadCli').load();
 
     await config.insertDefaults();
 
-    // Start all timer
     timerTask.startTimer(await config.getValue("cron"));
     setInterval(async () => require('./tasks/speedtest').removeOld(), 60000);
 
-    // Start integration interval
     integrationTask.startTimer();
-
-    // Make a speedtest
-    timerTask.runTask().then(undefined);
+    if (process.env.RUN_TEST_ON_STARTUP === "true") {
+        timerTask.runTask().then(undefined);
+    }
 
     app.listen(port, () => console.log(`Server listening on port ${port}`));
 }


### PR DESCRIPTION
# 🐛 Neustart triggert neuen Speedtest

In den damaligen Version von MySpeed war es wichtig, beim Startup automatisch einen Test zu erstellen, da die UI sonst nicht schön dargestellt wurde. Diese Entscheidung ist mittlerweile allerdings unnötig und wird daher hinter die Umgebungsvariable `RUN_TEST_ON_STARTUP` gesetzt. Ist diese auf `true`, funktioniert dies weiterhin. Ist sie das nicht, wird kein Test beim Startup generiert. 

Dadurch wird #547 behoben.

## Änderungen vorgenommen an ...

- [x] Server
- [ ] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___