### PR TITLE
🔍 Demo-Modus hinzugefügt

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -245,6 +245,7 @@
     "update_password": "Please update the password of this node",
     "password_outdated": "Password outdated",
     "password_updated": "The password has been successfully updated",
+    "preview_active": "Adding and deleting servers is disabled during demo mode.",
     "placeholder": {
       "name": "MySpeed instance",
       "url": "https://your-server.com"
@@ -265,8 +266,14 @@
       "tests_pending": "Test results pending"
     }
   },
+  "preview": {
+    "title": "Demo mode",
+    "info": "DEMO",
+    "description": "You are currently in demo mode. Some features are disabled and some settings cannot be changed. If you want to use all features, you can <Link>install MySpeed</Link> on your own server."
+  },
   "integrations": {
     "none_active": "This integration is not active. <br/><Bold>Create</Bold>",
+    "preview_active": "Integrations are disabled during demo mode.",
     "display_name": "Integration name",
     "create": "Create",
     "activity": {

--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -45,6 +45,7 @@
     "language": "Change language",
     "view": "Switch view",
     "info": "About the project",
+    "provider": "About the provider",
     "integrations": "Integrations"
   },
   "options": {
@@ -106,6 +107,7 @@
     "running_tooltip": "Speedtest running",
     "start_tooltip": "Start speedtest",
     "new_update": "Update available",
+    "download": "Download",
     "paused": "Speedtests are currently paused. Please continue them if you want to do one.",
     "running": "A speedtest is already running. Please wait a moment.",
     "admin_login": "Admin Login",

--- a/client/src/common/components/Dropdown/DropdownComponent.jsx
+++ b/client/src/common/components/Dropdown/DropdownComponent.jsx
@@ -242,6 +242,8 @@ function DropdownComponent() {
 
     const showCredits = () => setDialog({title: "MySpeed", description: creditsInfo(), buttonText: t("dialog.close")});
 
+    const showProviderDetails = () => setDialog({title: t("dropdown.provider"), description: config.previewMessage, buttonText: t("dialog.close")});
+
     const options = [
         {run: updatePing, icon: faPingPongPaddleBall, text: t("dropdown.ping")},
         {run: updateUpload, icon: faArrowUp, text: t("dropdown.upload")},
@@ -258,7 +260,8 @@ function DropdownComponent() {
         {hr: true, key: 2},
         {run: updateLanguage, icon: faGlobeEurope, text: t("dropdown.language"), allowView: true},
         {run: () => setShowViewDialog(true), icon: faChartSimple, allowView: true, text: t("dropdown.view")},
-        {run: showCredits, icon: faInfo, text: t("dropdown.info"), allowView: true}
+        {run: showCredits, icon: faInfo, text: t("dropdown.info"), allowView: true, previewHidden: true},
+        {run: showProviderDetails, icon: faInfo, text: t("dropdown.provider"), previewShown: true}
     ];
 
     return (
@@ -271,6 +274,7 @@ function DropdownComponent() {
                     <div className="dropdown-entries">
                         {options.map(entry => {
                             if (entry.previewHidden && config.previewMode) return;
+                            if (entry.previewShown && !config.previewMode) return;
                             if (!config.viewMode || (config.viewMode && entry.allowView)) {
                                 if (!entry.hr) {
                                     return (<div className="dropdown-item" onClick={() => {

--- a/client/src/common/components/Dropdown/DropdownComponent.jsx
+++ b/client/src/common/components/Dropdown/DropdownComponent.jsx
@@ -26,7 +26,7 @@ import {StatusContext} from "@/common/contexts/Status";
 import {InputDialogContext} from "@/common/contexts/InputDialog";
 import {SpeedtestContext} from "@/common/contexts/Speedtests";
 import {baseRequest, downloadRequest, jsonRequest, patchRequest, postRequest} from "@/common/utils/RequestUtil";
-import {creditsInfo, healthChecksInfo, recommendationsInfo} from "@/common/components/Dropdown/utils/infos";
+import {creditsInfo, recommendationsInfo} from "@/common/components/Dropdown/utils/infos";
 import {
     exportOptions, languageOptions, levelOptions,
     selectOptions, timeOptions
@@ -249,7 +249,7 @@ function DropdownComponent() {
         {run: recommendedSettings, icon: faWandMagicSparkles, text: t("dropdown.recommendations")},
         {hr: true, key: 1},
         {run: updateServer, icon: faServer, text: t("dropdown.server")},
-        {run: updatePassword, icon: faKey, text: t("dropdown.password")},
+        {run: updatePassword, icon: faKey, text: t("dropdown.password"), previewHidden: true},
         {run: updateCron, icon: faClock, text: t("dropdown.cron")},
         {run: updateTime, icon: faCalendarDays, text: t("dropdown.time"), allowView: true},
         {run: exportDialog, icon: faFileExport, text: t("dropdown.export")},
@@ -270,6 +270,7 @@ function DropdownComponent() {
                     <h2>{t("dropdown.settings")}</h2>
                     <div className="dropdown-entries">
                         {options.map(entry => {
+                            if (entry.previewHidden && config.previewMode) return;
                             if (!config.viewMode || (config.viewMode && entry.allowView)) {
                                 if (!entry.hr) {
                                     return (<div className="dropdown-item" onClick={() => {

--- a/client/src/common/components/Dropdown/utils/infos.jsx
+++ b/client/src/common/components/Dropdown/utils/infos.jsx
@@ -1,12 +1,8 @@
-import {PROJECT_URL, PROJECT_WIKI} from "@/index";
+import {WEB_URL} from "@/index";
 import {Trans} from "react-i18next";
-const HEALTHCHECKS_URL = "https://healthchecks.io/";
 const CLI_URL = "https://www.speedtest.net/apps/cli";
 
-export const healthChecksInfo = () => <Trans components={{HCLink: <a href={HEALTHCHECKS_URL} target="_blank"/>,
-    WIKILink: <a href={PROJECT_WIKI + "/instructions/settings"} target="_blank"/>}}>info.healthchecks</Trans>
-
-export const creditsInfo = () => <Trans components={{Link: <a href={PROJECT_URL} target="_blank" />,
+export const creditsInfo = () => <Trans components={{Link: <a href={WEB_URL} target="_blank" />,
     CLILink: <a href={CLI_URL} target="_blank"/>}}>info.credits</Trans>
 
 export const recommendationsInfo = (ping, down, up) => <Trans components={{Bold: <span className="dialog-value" />}}

--- a/client/src/common/components/Header/HeaderComponent.jsx
+++ b/client/src/common/components/Header/HeaderComponent.jsx
@@ -1,7 +1,7 @@
 import "./styles.sass";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {
-    faCircleArrowUp,
+    faCircleArrowUp, faDownload,
     faGaugeHigh,
     faGear,
     faLock,
@@ -78,6 +78,8 @@ function HeaderComponent(props) {
         postRequest("/speedtests/run").then(updateTests).then(updateStatus).then(() => setStartedManually(false));
     }
 
+    const openDownloadPage = () => window.open(WEB_URL + "/install", "_blank");
+
     useEffect(() => {
         if (Object.keys(config).length === 0) return;
         async function updateVersion() {
@@ -125,6 +127,11 @@ function HeaderComponent(props) {
                     {(config.viewMode ? <div className="tooltip-element tooltip-bottom">
                         <FontAwesomeIcon icon={faLock} className={"header-icon"} onClick={showPasswordDialog}/>
                         <span className="tooltip">{t("header.admin_login")}</span>
+                    </div> : <></>)}
+
+                    {(config.previewMode ? <div className="tooltip-element tooltip-bottom">
+                        <FontAwesomeIcon icon={faDownload} className={"header-icon"} onClick={openDownloadPage}/>
+                        <span className="tooltip">{t("header.download")}</span>
                     </div> : <></>)}
 
                     <div className="tooltip-element tooltip-bottom" id="open-header">

--- a/client/src/common/components/Header/HeaderComponent.jsx
+++ b/client/src/common/components/Header/HeaderComponent.jsx
@@ -18,6 +18,8 @@ import {t} from "i18next";
 import {ConfigContext} from "@/common/contexts/Config";
 import {LoadingDialog} from "@/common/components/LoadingDialog";
 import {NodeContext} from "@/common/contexts/Node";
+import {WEB_URL} from "@/index";
+import {Trans} from "react-i18next";
 
 function HeaderComponent(props) {
     const findNode = useContext(NodeContext)[4];
@@ -34,6 +36,12 @@ function HeaderComponent(props) {
     function switchDropdown() {
         toggleDropdown(setIcon);
     }
+
+    const showDemoDialog = () => setDialog({
+        title: t("preview.title"),
+        description: <Trans components={{Link: <a href={WEB_URL + "/install"} target="_blank" />}}>preview.description</Trans>,
+        buttonText: t("dialog.okay")
+    });
 
     const showPasswordDialog = () => setDialog({
         title: t("header.admin_login"),
@@ -90,7 +98,13 @@ function HeaderComponent(props) {
         <header>
             <LoadingDialog isOpen={startedManually}/>
             <div className="header-main">
-                {config.viewMode ? <h2>{t("header.title")}</h2> : <h2 onClick={() => props.showNodePage(true)} className="h2-click"><FontAwesomeIcon icon={faServer} /> {getNodeName()}</h2>}
+                <div className="header-left">
+                    {config.viewMode && <h2>{t("header.title")}</h2>}
+                    {!config.viewMode &&  <h2 onClick={() => props.showNodePage(true)} className="h2-click"><FontAwesomeIcon icon={faServer} /> {getNodeName()}</h2>}
+
+                    {config.previewMode && <h2 className="demo-info" onClick={showDemoDialog}>{t("preview.info")}</h2>}
+                </div>
+
 
                 <div className="header-right">
                     {updateAvailable ?

--- a/client/src/common/components/Header/styles.sass
+++ b/client/src/common/components/Header/styles.sass
@@ -16,13 +16,26 @@
 .header-main *
   font-size: 24pt
 
-.header-main h2
+.header-left
   margin-left: 10%
   display: flex
-  gap: 1rem
+  gap: 0.5rem
   align-items: center
+
+.demo-info
+  display: flex
+  cursor: pointer
+  align-items: center
+  justify-content: center
+  font-size: 14pt
+  background-color: $dark-gray
+  color: $green
+  margin: 0
+
+.header-main h2
   padding: 0.5rem 1rem
   border-radius: 1rem
+  margin: 0
 
 .header-main .h2-click
   cursor: pointer
@@ -68,24 +81,30 @@
   100%
     box-shadow: 0 0 0 0 #CCA92C00
 
+@media screen and (max-width: 600px)
+  .header-left
+    flex-direction: column
+    gap: 0
+
 @media (max-width: 460px)
   .header-main
     justify-content: center
-  .header-main div
+  .header-left div
     margin-right: 0
-  .header-main h2
+  .header-left .h2-click
     margin-left: 0
-    font-size: 24pt
+    font-size: 22pt
   .header-icon
     width: 25px
     height: 25px
 
-
-@media (max-width: 360px)
-  .header-main h2
-    font-size: 16pt
+@media (max-width: 410px)
+  .header-left .h2-click
+    font-size: 14pt
     text-overflow: ellipsis
     overflow: hidden
+  .header-left svg
+    font-size: 14pt
   .header-icon
     width: 20px
     height: 20px

--- a/client/src/common/components/Header/styles.sass
+++ b/client/src/common/components/Header/styles.sass
@@ -21,6 +21,9 @@
   display: flex
   gap: 0.5rem
   align-items: center
+  justify-content: center
+  overflow: hidden
+  text-overflow: ellipsis
 
 .demo-info
   display: flex
@@ -38,6 +41,9 @@
   margin: 0
 
 .header-main .h2-click
+  display: flex
+  gap: 1rem
+  align-items: center
   cursor: pointer
   user-select: none
 
@@ -53,6 +59,8 @@
 
 .header-icon
   cursor: pointer
+  display: flex
+
   transition: all 50ms ease-in-out
   width: 30px
   height: 30px
@@ -87,7 +95,6 @@
 @media screen and (max-width: 650px)
   .header-left
     flex-direction: column
-    gap: 0
 
 @media (max-width: 530px)
   .header-main
@@ -113,8 +120,10 @@
     height: 20px
 
 @media screen and (max-width: 365px)
+  .header-main .h2-click
+    gap: 0
   .header-left svg
-    display: none
+    margin-right: 0
   .demo-info
     font-size: 12pt
     padding: 0

--- a/client/src/common/components/Header/styles.sass
+++ b/client/src/common/components/Header/styles.sass
@@ -1,7 +1,7 @@
 @import "@/common/styles/colors"
 
 .header-main
-  margin-top: 2rem
+  margin-top: 3rem
   display: flex
   align-items: center
   justify-content: space-between
@@ -40,6 +40,9 @@
 .header-main .h2-click
   cursor: pointer
   user-select: none
+
+  svg
+    margin-right: 0.3rem
 
 .header-main .h2-click:hover
   color: $green-hover
@@ -81,12 +84,12 @@
   100%
     box-shadow: 0 0 0 0 #CCA92C00
 
-@media screen and (max-width: 600px)
+@media screen and (max-width: 650px)
   .header-left
     flex-direction: column
     gap: 0
 
-@media (max-width: 460px)
+@media (max-width: 530px)
   .header-main
     justify-content: center
   .header-left div
@@ -98,7 +101,7 @@
     width: 25px
     height: 25px
 
-@media (max-width: 410px)
+@media (max-width: 480px)
   .header-left .h2-click
     font-size: 14pt
     text-overflow: ellipsis
@@ -108,3 +111,10 @@
   .header-icon
     width: 20px
     height: 20px
+
+@media screen and (max-width: 365px)
+  .header-left svg
+    display: none
+  .demo-info
+    font-size: 12pt
+    padding: 0

--- a/client/src/common/components/IntegrationDialog/IntegrationDialog.jsx
+++ b/client/src/common/components/IntegrationDialog/IntegrationDialog.jsx
@@ -2,7 +2,7 @@ import {DialogContext, DialogProvider} from "@/common/contexts/Dialog";
 import "./styles.sass";
 import React, {useContext, useEffect, useState} from "react";
 import {t} from "i18next";
-import {faClose} from "@fortawesome/free-solid-svg-icons";
+import {faClose, faExclamationTriangle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {jsonRequest} from "@/common/utils/RequestUtil";
 import IntegrationItem from "@/common/components/IntegrationDialog/components/IntegrationItem";
@@ -10,9 +10,11 @@ import {v4 as uuid} from 'uuid';
 import AvailableIntegrations from "./components/AvailableIntegrations";
 import IntegrationAddButton from "@/common/components/IntegrationDialog/components/IntegrationAddButton";
 import NoIntegrationsTab from "@/common/components/IntegrationDialog/components/NoIntegrationsTab";
+import {ConfigContext} from "@/common/contexts/Config";
 
 export const Dialog = ({integrations, active, setActive}) => {
     const close = useContext(DialogContext);
+    const [config] = useContext(ConfigContext);
     const [currentTab, setCurrentTab] = useState(integrations[Object.keys(integrations)[0]].name);
 
     const addIntegration = () => setActive([...active, {uuid: uuid(), name: currentTab,
@@ -31,6 +33,12 @@ export const Dialog = ({integrations, active, setActive}) => {
                                        setCurrentTab={setCurrentTab}/>
 
                 <div className="integrations-tab">
+                    {config.previewMode && active.filter(item => item.name === currentTab).length > 0
+                        && <div className="pr-integration-container">
+                            <FontAwesomeIcon icon={faExclamationTriangle} />
+                            <p>{t("integrations.preview_active")}</p>
+                    </div>}
+
                     {active.map((item) => (item.name !== currentTab ? undefined :
                         <IntegrationItem integration={integrations[currentTab]}
                                          remove={() => deleteIntegration(item.uuid)}

--- a/client/src/common/components/IntegrationDialog/components/IntegrationItem/components/IntegrationItemHeader/IntegrationItemHeader.jsx
+++ b/client/src/common/components/IntegrationDialog/components/IntegrationItem/components/IntegrationItemHeader/IntegrationItemHeader.jsx
@@ -10,11 +10,13 @@ import {
     faTrashArrowUp
 } from "@fortawesome/free-solid-svg-icons";
 import "./styles.sass";
-import {useEffect, useState} from "react";
+import {useContext, useEffect, useState} from "react";
+import {ConfigContext} from "@/common/contexts/Config";
 
 export const IntegrationItemHeader = ({integration, displayName, unsavedChanges, changesConfirmed, saveIntegration,
                                           deleteConfirmed, deleteIntegration, open, setOpen, data}) => {
     const [lastActivity, setLastActivity] = useState(generateRelativeTime(data.lastActivity));
+    const [config] = useContext(ConfigContext);
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -40,11 +42,11 @@ export const IntegrationItemHeader = ({integration, displayName, unsavedChanges,
             </div>
         </div>
         <div className="integration-item-right">
-            {unsavedChanges && !changesConfirmed && <FontAwesomeIcon icon={faFloppyDisk} onClick={saveIntegration}
+            {!config.previewMode && unsavedChanges && !changesConfirmed && <FontAwesomeIcon icon={faFloppyDisk} onClick={saveIntegration}
                                                                      className="integration-green"/>}
             {changesConfirmed && <FontAwesomeIcon icon={faCheck} className="icon-green"/>}
 
-            {!deleteConfirmed &&
+            {!config.previewMode && !deleteConfirmed &&
                 <FontAwesomeIcon icon={faTrash} className="integration-red" onClick={deleteIntegration}/>}
             {deleteConfirmed &&
                 <FontAwesomeIcon icon={faTrashArrowUp} className="integration-red" onClick={deleteIntegration}/>}

--- a/client/src/common/components/IntegrationDialog/styles.sass
+++ b/client/src/common/components/IntegrationDialog/styles.sass
@@ -17,6 +17,21 @@
   overflow-x: clip
   width: 70%
 
+  .pr-integration-container
+    display: flex
+    gap: 0.5rem
+    align-items: center
+    justify-content: center
+    padding: 0.5rem
+    border-radius: 0.5rem
+    border: 2px solid $red
+    color: $red
+    font-size: 1.25rem
+
+    p
+      margin: 0
+      font-weight: 500
+
 @media (max-width: 781px)
   .integration-dialog
     width: 90vw

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from './App';
 
 export const PROJECT_URL = "https://github.com/gnmyt/myspeed";
+export const WEB_URL = "https://myspeed.dev";
 export const PROJECT_WIKI = "https://docs.myspeed.dev";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/client/src/pages/Nodes/Nodes.jsx
+++ b/client/src/pages/Nodes/Nodes.jsx
@@ -5,10 +5,18 @@ import {useContext, useEffect, useState} from "react";
 import {NodeContext} from "@/common/contexts/Node";
 import {t} from "i18next";
 import CreateNodeDialog from "@/pages/Nodes/components/CreateNodeDialog";
+import {ConfigContext} from "@/common/contexts/Config";
+import {InputDialogContext} from "@/common/contexts/InputDialog";
 
 export const Nodes = (props) => {
+    const [config] = useContext(ConfigContext);
     const [nodes, updateNodes] = useContext(NodeContext);
+    const [setDialog] = useContext(InputDialogContext);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+    const openPreviewInfoDialog = () => {
+        setDialog({title: t("preview.title"), description: t("nodes.preview_active"), buttonText: t("dialog.close")});
+    }
 
     useEffect(() => {
         updateNodes();
@@ -24,7 +32,8 @@ export const Nodes = (props) => {
 
                 {nodes.map(node => <NodeContainer {...node} key={node.id} setShowNodePage={props.setShowNodePage} />)}
 
-                <div className="node-add" onClick={() => setCreateDialogOpen(true)}>
+                <div className={"node-add" + (config.previewMode ? " node-disabled" : "")} onClick={() => config.previewMode
+                    ? openPreviewInfoDialog() : setCreateDialogOpen(true)}>
                     <h1>{t("nodes.add")}</h1>
                 </div>
             </div>

--- a/client/src/pages/Nodes/styles.sass
+++ b/client/src/pages/Nodes/styles.sass
@@ -39,6 +39,19 @@
   h1
     color: $white
 
+.node-disabled
+  width: 53rem
+  border: 2px dashed #696C73
+  border-radius: 15px
+  cursor: not-allowed
+  user-select: none
+
+.node-disabled:hover
+  border: 2px dashed #696C73
+
+  h1
+    color: $darker-white
+
 @media screen and (max-width: 862px)
   .node-add
     width: calc(20vw + 11rem)

--- a/client/src/pages/Statistics/Statistics.jsx
+++ b/client/src/pages/Statistics/Statistics.jsx
@@ -33,7 +33,7 @@ const generatePath = (level = 1) => {
 ChartJS.register(ArcElement, Tooltip, CategoryScale, LinearScale, PointElement, LineElement, Title, Legend, RadialLinearScale);
 ChartJS.defaults.color = "#B0B0B0";
 ChartJS.defaults.font.color = "#B0B0B0";
-ChartJS.defaults.font.family = "Roboto";
+ChartJS.defaults.font.family = "Inter, sans-serif";
 
 
 export const Statistics = () => {

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1,7 +1,9 @@
 const {Sequelize} = require('sequelize');
 
+const STORAGE_PATH = `data/storage${process.env.PREVIEW_MODE === "true" ? "_preview" : ""}.db`;
+
 Sequelize.DATE.prototype._stringify = () => {
     return new Date().toISOString();
 }
 
-module.exports = new Sequelize({dialect: 'sqlite', storage: 'data/storage.db', logging: false, query: {raw: true}});
+module.exports = new Sequelize({dialect: 'sqlite', storage: STORAGE_PATH, logging: false, query: {raw: true}});

--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -27,6 +27,7 @@ module.exports.listAll = async () => {
 }
 
 module.exports.getValue = async (key) => {
+    if (process.env.PREVIEW_MODE === "true" && key === "acceptOoklaLicense") return true;
     return (await config.findByPk(key)).value;
 }
 

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -74,8 +74,11 @@ module.exports.listStatistics = async (days) => {
 
     let notFailed = dbEntries.filter((entry) => entry.error === null);
 
-    let data = ["ping", "download", "upload", "time"]
-        .map((item) => days >= 3 ? avgEntries.map(entry => entry[item]) : notFailed.map(entry => entry[item]));
+    let data = {};
+    ["ping", "download", "upload", "time"].forEach(item => {
+        data[item] = days >= 3 ? avgEntries.map(entry => entry[item]) : notFailed.map(entry => entry[item]);
+    });
+
 
     return {
         tests: {

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const app = express();
 
 app.disable('x-powered-by');
 
-const port = process.env.port || 5216;
+const port = process.env.SERVER_PORT || 5216;
 
 require('./util/createFolders');
 require('./util/loadServers');

--- a/server/index.js
+++ b/server/index.js
@@ -43,7 +43,7 @@ const run = async () => {
 
     await require('./controller/integrations').initialize();
 
-    await require('./util/loadCli').load();
+    if (process.env.PREVIEW_MODE !== "true") await require('./util/loadCli').load();
 
     await config.insertDefaults();
 

--- a/server/middlewares/password.js
+++ b/server/middlewares/password.js
@@ -2,6 +2,8 @@ const config = require('../controller/config');
 const bcrypt = require('bcrypt');
 
 module.exports = (allowViewAccess) => async (req, res, next) => {
+    if (process.env.PREVIEW_MODE === "true") return next();
+
     let passwordHash = await config.getValue("password");
     let passwordLevel = await config.getValue("passwordLevel");
 

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -9,8 +9,11 @@ app.get("/", password(true), async (req, res) => {
     (await config.listAll()).forEach(row => {
         if (row.key !== "password" && !(req.viewMode && ["serverId", "cron", "passwordLevel"].includes(row.key)))
             configValues[row.key] = row.value;
+        if (process.env.PREVIEW_MODE === "true" && row.key === "acceptOoklaLicense")
+            configValues[row.key] = true;
     });
     configValues['viewMode'] = req.viewMode;
+    configValues['previewMode'] = process.env.PREVIEW_MODE === "true";
 
     if (Object.keys(configValues).length === 0) return res.status(404).json({message: "Hmm. There are no config values. Weird..."});
     res.json(configValues);
@@ -38,6 +41,12 @@ app.patch("/:key", password(false), async (req, res) => {
 
     if (!await config.updateValue(req.params.key, req.body.value.toString()))
         return res.status(404).json({message: "The provided key does not exist"});
+
+    if (process.env.PREVIEW_MODE === "true" && req.params.key === "acceptOoklaLicense")
+        return res.status(403).json({message: "You can't change the Ookla license acceptance in preview mode"});
+
+    if (process.env.PREVIEW_MODE === "true" && (req.params.key === "password" || req.params.key === "passwordLevel"))
+        return res.status(403).json({message: "You can't change the password in preview mode"});
 
     if (req.params.key === "cron") {
         timer.stopTimer();

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -15,6 +15,9 @@ app.get("/", password(true), async (req, res) => {
     configValues['viewMode'] = req.viewMode;
     configValues['previewMode'] = process.env.PREVIEW_MODE === "true";
 
+    if (process.env.PREVIEW_MODE === "true")
+        configValues['previewMessage'] = String(process.env.PREVIEW_MESSAGE || "The owner of this instance has not provided a message");
+
     if (Object.keys(configValues).length === 0) return res.status(404).json({message: "Hmm. There are no config values. Weird..."});
     res.json(configValues);
 });

--- a/server/routes/integrations.js
+++ b/server/routes/integrations.js
@@ -11,6 +11,9 @@ app.put("/:integrationName", password(false), async (req, res) => {
     const integration = integrations.getIntegration(req.params.integrationName);
     if (!integration) return res.status(404).json({message: "Integration not found"});
 
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't create integrations in preview mode"});
+
     if (!req.body) return res.status(400).json({message: "Missing data"});
 
     const validatedInput = validateInput(req.params.integrationName, req.body);
@@ -23,6 +26,9 @@ app.put("/:integrationName", password(false), async (req, res) => {
 app.patch("/:id", password(false), async (req, res) => {
     if (!req.body) return res.status(400).json({message: "Missing data"});
 
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't update integrations in preview mode"});
+
     const integration = await integrations.getIntegrationById(req.params.id);
     if (!integration) return res.status(404).json({message: "Integration not found"});
 
@@ -34,6 +40,9 @@ app.patch("/:id", password(false), async (req, res) => {
 });
 
 app.delete("/:id", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't delete integrations in preview mode"});
+
     const result = await integrations.delete(req.params.id);
     if (result === null) return res.status(404).json({message: "Integration not found"});
     return res.json({message: "Integration deleted"});

--- a/server/routes/nodes.js
+++ b/server/routes/nodes.js
@@ -7,6 +7,9 @@ app.get("/", password(false), async (req, res) => {
 });
 
 app.put("/", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't create nodes in preview mode"});
+
     if (!req.body.name || !req.body.url) return res.status(400).json({message: "Missing parameters", type: "MISSING_PARAMETERS"});
 
     const url = req.body.url.replace(/\/+$/, "");
@@ -23,6 +26,9 @@ app.put("/", password(false), async (req, res) => {
 });
 
 app.delete("/:nodeId", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't delete nodes in preview mode"});
+
     const node = await nodes.getOne(req.params.nodeId);
     if (node === null) return res.status(404).json({message: "Node not found"});
 
@@ -31,6 +37,9 @@ app.delete("/:nodeId", password(false), async (req, res) => {
 });
 
 app.patch("/:nodeId/name", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't update nodes in preview mode"});
+
     if (!req.body.name) return res.status(400).json({message: "Missing parameters", type: "MISSING_PARAMETERS"});
 
     const node = await nodes.getOne(req.params.nodeId);
@@ -41,6 +50,9 @@ app.patch("/:nodeId/name", password(false), async (req, res) => {
 });
 
 app.patch("/:nodeId/password", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true")
+        return res.status(403).json({message: "For security reasons, you can't update nodes in preview mode"});
+
     if (!req.body.password) return res.status(400).json({message: "Missing parameters", type: "MISSING_PARAMETERS"});
 
     const node = await nodes.getOne(req.params.nodeId);

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -5,7 +5,11 @@ const axios = require('axios');
 const fs = require("fs");
 const password = require('../middlewares/password');
 
+const servers = fs.readFileSync("./data/servers.json", "utf8") || "[]";
+
 app.get("/version", password(false), async (req, res) => {
+    if (process.env.PREVIEW_MODE === "true") return res.json({local: version, remote: "0"});
+
     try {
         res.json({local: version, remote: ((await axios.get(remote_url)).data.tag_name).replace("v", "")});
     } catch (e) {
@@ -14,10 +18,7 @@ app.get("/version", password(false), async (req, res) => {
 });
 
 app.get("/server", password(false), (req, res) => {
-    fs.readFile("./data/servers.json", "utf8", (err, data) => {
-        if (err) return res.status(500).json({message: "Could not read servers"});
-        res.json(JSON.parse(data.toString()));
-    });
+    res.json(JSON.parse(servers.toString()));
 });
 
 module.exports = app;

--- a/server/tasks/speedtest.js
+++ b/server/tasks/speedtest.js
@@ -57,7 +57,18 @@ module.exports.create = async (type = "auto", retried = false) => {
     if (isRunning && !retried) return 500;
 
     try {
-        let test = await this.run(retried);
+        let test;
+        if (process.env.PREVIEW_MODE === "true") {
+            await new Promise(resolve => setTimeout(resolve, 5000));
+            test = {
+                ping: {latency: Math.floor(Math.random() * 250) + 5},
+                download: {bytes: Math.floor(Math.random() * 1000000000) + 1000000, elapsed: 10000},
+                upload: {bytes: Math.floor(Math.random() * 1000000000) + 1000000, elapsed: 10000}
+            }
+        } else {
+            test = await this.run(retried);
+        }
+
         let ping = Math.round(test.ping.latency);
         let download = roundSpeed(test.download.bytes, test.download.elapsed);
         let upload = roundSpeed(test.upload.bytes, test.upload.elapsed);


### PR DESCRIPTION
# 🔍 Demo-Modus hinzugefügt

> [!CAUTION]
> Der Demo-Modus ist nicht für den Produktivgebrauch auf privaten Servern geeignet. Er dient dem Hosting einer öffentlichen MySpeed Demo-Instanz

Ich möchte zukünftig Nutzern die möglichkeit anbieten, MySpeed zu testen bevor sie es herunterladen. Das setzt sowohl eine Server-Infrastruktur als auch eine Funktion voraus, welche den Zugriff während des testens einschränkt.

Damit also der User nicht einfach das Passwort ändert und kein anderer MySpeed testen kann, werden mit dieser PR folgende Features innerhalb des Demo-Modes deaktiviert:
- Das erstellen, bearbeiten und löschen von Servern
- Das erstellen, bearbeiten und löschen von Integrationen
- Das ändern des Passworts und der Passwortstufe
- Das manuelle Festlegen der `acceptOoklaLicense`-Variable
- Das Abfragen der neusten Version von GitHubs Servern

Zudem generieren, um Bandbreite zu sparen, Speedtests Ergebnisse mit zufällligen Werten.

Aktivieren lässt sich der Demo-Modus, in dem man die Variable `PREVIEW_MODE` auf `true` setzt.

## Screenshots

![image](https://github.com/gnmyt/myspeed/assets/35641351/a9a36305-854f-4081-9e45-bb4c1fde61b6)


## Änderungen vorgenommen an ...

- [x] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___