### PR TITLE
👨‍💻 Interfaceauswahl hinzugefügt

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -34,11 +34,11 @@
       "description": "MySpeed could not reach the API of this instance. Please try again later."
     },
     "provider": {
+      "interface": "Interface",
       "server": "Server",
       "server_id": "Server ID",
       "choose_automatically": "Choose automatically",
-      "ookla_license": "I have read and accept the <Eula>EULA</Eula>, <GDPR>privacy policy</GDPR> and <TOS>terms of service</TOS> of Ookla.",
-      "cloudflare_note": "Cloudflare does not require any additional settings"
+      "ookla_license": "I have read and accept the <Eula>EULA</Eula>, <GDPR>privacy policy</GDPR> and <TOS>terms of service</TOS> of Ookla."
     }
   },
   "dropdown": {
@@ -210,7 +210,7 @@
     },
     "result": {
       "title": "Test result",
-      "description": "This test achieved a maximum download speed of <Bold>{{down}} Mbps</Bold> and a maximum upload speed of <Bold>{{up}} Mbps</Bold>. It was created <Bold>{{type}}</Bold> and took <Bold>{{duration}} Seconds</Bold>.",
+      "description": "<Link>This test</Link> achieved a maximum download speed of <Bold>{{down}} Mbps</Bold> and a maximum upload speed of <Bold>{{up}} Mbps</Bold>. It was created <Bold>{{type}}</Bold> and took <Bold>{{duration}} Seconds</Bold>.",
       "from_you": "by you",
       "automatic": "automatically"
     },

--- a/client/src/common/components/ProviderDialog/ProviderDialog.jsx
+++ b/client/src/common/components/ProviderDialog/ProviderDialog.jsx
@@ -28,6 +28,8 @@ export const Dialog = () => {
     const [licenseAccepted, setLicenseAccepted] = useState(false);
     const [licenseError, setLicenseError] = useState(false);
 
+    const [interfaces, setInterfaces] = useState({});
+    const [currentInterface, setCurrentInterface] = useState(config.interface || "none");
     const [ooklaServers, setOoklaServers] = useState({});
     const [libreServers, setLibreServers] = useState({});
 
@@ -39,6 +41,9 @@ export const Dialog = () => {
         });
         jsonRequest("/info/server/libre").then((response) => {
             setLibreServers(response);
+        });
+        jsonRequest("/info/interfaces").then((response) => {
+            setInterfaces(response);
         });
     }, []);
 
@@ -60,6 +65,10 @@ export const Dialog = () => {
 
         if (serverId !== config[provider + "Id"] && provider !== "cloudflare") {
             await patchRequest("/config/" + provider + "Id", {value: serverId});
+        }
+
+        if (currentInterface !== config.interface) {
+            await patchRequest("/config/interface", {value: currentInterface});
         }
 
         reloadConfig();
@@ -84,43 +93,53 @@ export const Dialog = () => {
                         </div>
                     ))}
                 </div>
-                {provider !== "cloudflare" && <div className="provider-content">
+                <div className="provider-content">
                     <div className="provider-setting">
-                        <h3>{t("dialog.provider.server")}</h3>
-                        <select className="dialog-input provider-input" value={serverId}
-                                onChange={(e) => setServerId(e.target.value)}>
-                            <option value="none">{t("dialog.provider.choose_automatically")}</option>
-                            {provider === "ookla" && Object.keys(ooklaServers).map((current, index) => (
-                                <option key={index} value={current}>{ooklaServers[current]}</option>
-                            ))}
-                            {provider === "libre" && Object.keys(libreServers).map((current, index) => (
-                                <option key={index} value={current}>{libreServers[current]}</option>
+                        <h3>{t("dialog.provider.interface")}</h3>
+                        <select className="dialog-input provider-input" value={currentInterface}
+                                onChange={(e) => setCurrentInterface(e.target.value)}>
+                            {interfaces && Object.keys(interfaces).map((current, index) => (
+                                <option key={index} value={current}>{current} ({interfaces[current]})</option>
                             ))}
                         </select>
                     </div>
-                    <div className="provider-setting">
-                        <h3>{t("dialog.provider.server_id")}</h3>
-                        <input type="text" className="dialog-input provider-input" value={serverId === "none" ? "" : serverId}
-                                 onChange={(e) => setServerId(e.target.value)}/>
-                    </div>
-                </div>}
-                {provider === "cloudflare" && <div className="provider-content">
-                    <p className="cloudflare-provider-info">{t("dialog.provider.cloudflare_note")}</p>
-                </div>}
+
+                    {provider !== "cloudflare" && <>
+                        <div className="provider-setting">
+                            <h3>{t("dialog.provider.server")}</h3>
+                            <select className="dialog-input provider-input" value={serverId}
+                                    onChange={(e) => setServerId(e.target.value)}>
+                                <option value="none">{t("dialog.provider.choose_automatically")}</option>
+                                {provider === "ookla" && Object.keys(ooklaServers).map((current, index) => (
+                                    <option key={index} value={current}>{ooklaServers[current]}</option>
+                                ))}
+                                {provider === "libre" && Object.keys(libreServers).map((current, index) => (
+                                    <option key={index} value={current}>{libreServers[current]}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="provider-setting">
+                            <h3>{t("dialog.provider.server_id")}</h3>
+                            <input type="text" className="dialog-input provider-input"
+                                   value={serverId === "none" ? "" : serverId}
+                                   onChange={(e) => setServerId(e.target.value)}/>
+                        </div>
+                    </>}
+                </div>
             </div>
             <div className="provider-dialog-footer">
                 <div className="provider-license-box">
                     {provider === "ookla" && <>
                         <input type="checkbox" className={licenseError ? "cb-error" : ""} id="license" name="license"
-                                 onChange={(e) => setLicenseAccepted(e.target.checked)}/>
+                               onChange={(e) => setLicenseAccepted(e.target.checked)}/>
                         <label htmlFor="license"
                         ><Trans components={{
                             Eula: <a href="https://www.speedtest.net/about/eula" target="_blank"
-                                     rel="noreferrer" />,
+                                     rel="noreferrer"/>,
                             GDPR: <a href="https://www.speedtest.net/about/privacy" target="_blank"
-                                     rel="noreferrer" />,
+                                     rel="noreferrer"/>,
                             TOS: <a href="https://www.speedtest.net/about/terms" target="_blank"
-                                    rel="noreferrer" />}}>dialog.provider.ookla_license</Trans></label>
+                                    rel="noreferrer"/>}}>dialog.provider.ookla_license</Trans></label>
                     </>}
                 </div>
 

--- a/client/src/common/contexts/Dialog/styles.sass
+++ b/client/src/common/contexts/Dialog/styles.sass
@@ -66,6 +66,7 @@
 
 .dialog-description a
   color: $green
+  text-decoration: underline
 
 .dialog-value
   color: $green

--- a/client/src/pages/Home/components/Speedtest/utils/infos.jsx
+++ b/client/src/pages/Home/components/Speedtest/utils/infos.jsx
@@ -2,11 +2,14 @@ import React from "react";
 import {Trans} from "react-i18next";
 import {t} from "i18next";
 
+const RESULT_URL = "https://www.speedtest.net/result/c/";
+
 export const averageResultDialog = (timeString, props) => <Trans components={{Bold: <span className="dialog-value"/> }}
                                                                  values={{amount: props.amount, date: timeString, down: props.down,
                                                                      up: props.up, duration: props.duration}}>test.average.description</Trans>
 
-export const resultDialog = (props) => <Trans components={{Bold: <span className="dialog-value"/> }}
+export const resultDialog = (props) => <Trans components={{Bold: <span className="dialog-value"/>,
+    Link: (props.resultId ? <a href={RESULT_URL + props.resultId} target="_blank" rel="noreferrer"/> : <span/>) }}
                                               values={{down: props.down, up: props.up,
                                                   type: t("test.result." + (props.type === "custom" ? "from_you" : "automatic")),
                                                   duration: props.duration}}>test.result.description</Trans>

--- a/client/src/pages/Home/components/TestArea/TestAreaComponent.jsx
+++ b/client/src/pages/Home/components/TestArea/TestAreaComponent.jsx
@@ -36,6 +36,7 @@ function TestArea() {
                                   type={test.type}
                                   duration={test.time}
                                   amount={test.amount}
+                                  resultId={test.resultId}
                                   id={id}
                 />
             }) : ""}

--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -187,7 +187,7 @@ module.exports.factoryReset = async () => {
     timer.stopTimer();
     timer.startTimer(configDefaults.cron);
 
-    await interfaces.requestInterfaces();
+    interfaces.requestInterfaces();
 
     return true;
 }

--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -10,6 +10,7 @@ const cron = require('cron-validator');
 const db = require("../config/database");
 const fs = require('fs');
 const path = require('path');
+const interfaces = require('../util/loadInterfaces');
 
 const configDefaults = {
     ping: "25",
@@ -20,14 +21,23 @@ const configDefaults = {
     ooklaId: "none",
     libreId: "none",
     password: "none",
-    passwordLevel: "none"
+    passwordLevel: "none",
+    interface: "none"
 }
 
 module.exports.insertDefaults = async () => {
     let insert = [];
     for (let key in configDefaults) {
-        if (!(await config.findOne({where: {key: key}})))
+        if (key !== "interface" && !(await config.findOne({where: {key: key}})))
             insert.push({key: key, value: configDefaults[key]});
+
+        if (key === "interface") {
+            const ips = Object.keys(interfaces.interfaces);
+            let ip = ips.length > 0 ? ips[0] : "none";
+
+            if (!(await config.findOne({where: {key: key}})))
+                insert.push({key: key, value: ip});
+        }
     }
 
     await config.bulkCreate(insert, {validate: true});
@@ -93,6 +103,9 @@ module.exports.validateInput = async (key, value) => {
 
     if (key === "cron" && !cron.isValidCron(value.toString()))
         return "Not a valid cron expression";
+
+    if (key === "interface" && !Object.keys(interfaces.interfaces).includes(value))
+        return "The provided interface does not exist";
 
     if (configDefaults[key] === undefined)
         return "The provided key does not exist";

--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -187,5 +187,7 @@ module.exports.factoryReset = async () => {
     timer.stopTimer();
     timer.startTimer(configDefaults.cron);
 
+    await interfaces.requestInterfaces();
+
     return true;
 }

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -2,8 +2,8 @@ const tests = require('../models/Speedtests');
 const {Op, Sequelize} = require("sequelize");
 const {mapFixed, mapRounded, calculateTestAverages} = require("../util/helpers");
 
-module.exports.create = async (ping, download, upload, time, serverId, type = "auto", error = null) => {
-    return (await tests.create({ping, download, upload, error, serverId, type, time})).id;
+module.exports.create = async (ping, download, upload, time, serverId, type = "auto", resultId = null, error = null) => {
+    return (await tests.create({ping, download, upload, error, serverId, type, resultId, time, created: new Date().toISOString()})).id;
 }
 
 module.exports.getOne = async (id) => {
@@ -15,8 +15,10 @@ module.exports.getOne = async (id) => {
 
 module.exports.listAll = async () => {
     let dbEntries = await tests.findAll({order: [["created", "DESC"]]});
-    for (let dbEntry of dbEntries)
+    for (let dbEntry of dbEntries) {
         if (dbEntry.error === null) delete dbEntry.error;
+        if (dbEntry.resultId === null) delete dbEntry.resultId;
+    }
 
     return dbEntries;
 }
@@ -28,8 +30,10 @@ module.exports.listTests = async (hours = 24, start, limit) => {
     let dbEntries = (await tests.findAll({where: whereClause, order: [["created", "DESC"]], limit}))
         .filter((entry) => new Date(entry.created) > new Date().getTime() - hours * 3600000);
 
-    for (let dbEntry of dbEntries)
+    for (let dbEntry of dbEntries) {
         if (dbEntry.error === null) delete dbEntry.error;
+        if (dbEntry.resultId === null) delete dbEntry.resultId;
+    }
 
     return dbEntries;
 }
@@ -84,6 +88,7 @@ module.exports.importTests = async (data) => {
 
     for (let entry of data) {
         if (entry.error === null) delete entry.error;
+        if (entry.resultId === null) delete entry.resultId;
         try {
             await tests.create(entry);
         } catch (e) {

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,8 @@ const run = async () => {
 
     await require('./controller/integrations').initialize();
 
+    await require('./util/loadInterfaces').requestInterfaces();
+
     if (process.env.PREVIEW_MODE !== "true") await require('./util/loadCli').load();
 
     await config.insertDefaults();
@@ -60,7 +62,7 @@ const run = async () => {
 
 db.authenticate().then(() => {
     console.log("Successfully connected to the database " + (process.env.DB_TYPE === "mysql" ? "server" : "file"));
-        run().then(undefined);
+    run().then(undefined);
 }).catch(err => {
     console.error("Could not open the database file. Maybe it is damaged?: " + err.message);
     process.exit(111);

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ const run = async () => {
     await require('./controller/integrations').initialize();
 
     await require('./util/loadInterfaces').requestInterfaces();
+    setInterval(() => require('./util/loadInterfaces').requestInterfaces(), 3600000);
 
     if (process.env.PREVIEW_MODE !== "true") await require('./util/loadCli').load();
 

--- a/server/models/Speedtests.js
+++ b/server/models/Speedtests.js
@@ -31,8 +31,16 @@ module.exports = db.define("speedtests", {
         type: Sequelize.STRING,
         defaultValue: "auto"
     },
+    resultId: {
+        type: Sequelize.STRING,
+        allowNull: true
+    },
     time: {
         type: Sequelize.INTEGER,
         defaultValue: 0
+    },
+    created: {
+        type: Sequelize.TIME,
+        defaultValue: Sequelize.NOW
     }
-}, {createdAt: "created", updatedAt: false});
+}, {createdAt: false, updatedAt: false});

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -4,6 +4,7 @@ const remote_url = "https://api.github.com/repos/gnmyt/myspeed/releases/latest";
 const axios = require('axios');
 const password = require('../middlewares/password');
 const serverController = require('../controller/servers');
+const interfaces = require('../util/loadInterfaces');
 
 app.get("/version", password(false), async (req, res) => {
     if (process.env.PREVIEW_MODE === "true") return res.json({local: version, remote: "0"});
@@ -20,6 +21,10 @@ app.get("/server/:provider", password(false), (req, res) => {
         return res.status(400).json({message: "Invalid provider"});
 
     res.json(serverController.getByMode(req.params.provider));
+});
+
+app.get("/interfaces", password(false), async (req, res) => {
+    res.json(interfaces.interfaces);
 });
 
 module.exports = app;

--- a/server/tasks/speedtest.js
+++ b/server/tasks/speedtest.js
@@ -95,18 +95,17 @@ module.exports.create = async (type = "auto", retried = false) => {
             test = await this.run(retried);
         }
 
-        let {ping, download, upload, time} = await parseData.parseData(process.env.PREVIEW_MODE === "true" ?
+        let {ping, download, upload, time, resultId} = await parseData.parseData(process.env.PREVIEW_MODE === "true" ?
             "ookla" : mode, test);
 
-        let testResult = await tests.create(ping, download, upload, time, test.serverId, type);
+        let testResult = await tests.create(ping, download, upload, time, test.serverId, type, resultId);
         console.log(`Test #${testResult} was executed successfully in ${time}s. 🏓 ${ping} ⬇ ${download}️ ⬆ ${upload}️`);
         createRecommendations().then(() => "");
         setRunning(false);
         sendFinished({ping, download, upload, time}).then(() => "");
     } catch (e) {
-        console.log(e)
         if (!retried) return this.create(type, true);
-        let testResult = await tests.create(-1, -1, -1, null, 0, type, e.message);
+        let testResult = await tests.create(-1, -1, -1, null, 0, type, null, e.message);
         await sendError(e.message);
         setRunning(false, false);
         console.log(`Test #${testResult} was not executed successfully. Please try reconnecting to the internet or restarting the software: ` + e.message);

--- a/server/util/errorHandler.js
+++ b/server/util/errorHandler.js
@@ -5,6 +5,8 @@ module.exports = (error) => {
     const date = new Date().toLocaleString();
     const lineStarter = fs.existsSync(filePath) ? "\n\n" : "# Found a bug? Report it here: https://github.com/gnmyt/myspeed/issues\n\n";
 
+    console.error("An error occurred: " + error.message);
+
     fs.writeFile(filePath, lineStarter + "## " + date + "\n" + error, {flag: 'a+'}, err => {
         if (err) console.error("Could not save error log file.", error);
 

--- a/server/util/loadInterfaces.js
+++ b/server/util/loadInterfaces.js
@@ -1,12 +1,13 @@
 const os = require('os');
 const https = require('https');
-
-let interfacesNode = os.networkInterfaces();
-let interfaces = {};
+const config = require('../controller/config');
 
 let usableInterfaces = {};
 
 const requestInterfaces = async () => {
+    let interfacesNode = os.networkInterfaces();
+    let interfaces = {};
+
     console.log("Looking for network interfaces...");
     for (let i in interfacesNode) {
         for (let j in interfacesNode[i]) {
@@ -52,6 +53,13 @@ const requestInterfaces = async () => {
 
     for (let i in usableInterfaces) {
         console.log(`Found interface ${i} with IP ${usableInterfaces[i]}`);
+    }
+
+    const currentInterface = await config.getValue("interface");
+
+    if (!usableInterfaces[currentInterface]) {
+        console.warn(`Interface ${currentInterface} not found. Falling back to default.`);
+        await config.updateValue("interface", Object.keys(usableInterfaces)[0]);
     }
 }
 

--- a/server/util/loadInterfaces.js
+++ b/server/util/loadInterfaces.js
@@ -1,0 +1,59 @@
+const os = require('os');
+const https = require('https');
+
+let interfacesNode = os.networkInterfaces();
+let interfaces = {};
+
+let usableInterfaces = {};
+
+const requestInterfaces = async () => {
+    console.log("Looking for network interfaces...");
+    for (let i in interfacesNode) {
+        for (let j in interfacesNode[i]) {
+            let address = interfacesNode[i][j];
+
+            if (address.internal) continue;
+
+            let options = {hostname: "speed.cloudflare.com", path: "/__down?bytes=1", method: "GET",
+                family: address.family === "IPv4" ? 4 : 6, timeout: 5000};
+
+            options.agent = new https.Agent(options);
+            options.localAddress = address.address;
+
+            await new Promise((resolve) => {
+
+                const req = https.request(options, () => {
+                    if (!interfaces[i]) interfaces[i] = [];
+                    interfaces[i].push(address.address);
+                    req.destroy();
+                    resolve();
+                });
+
+                req.on('error', () => resolve());
+                req.on('timeout', () => req.destroy());
+
+                req.end();
+            });
+        }
+
+        if (!interfaces[i]) delete interfaces[i];
+    }
+
+    for (let i in interfaces) {
+        for (let j in interfaces[i]) {
+            if (interfaces[i][j].includes(".")) {
+                usableInterfaces[i] = interfaces[i][j];
+                break;
+            }
+        }
+
+        if (!usableInterfaces[i]) usableInterfaces[i] = interfaces[i][0];
+    }
+
+    for (let i in usableInterfaces) {
+        console.log(`Found interface ${i} with IP ${usableInterfaces[i]}`);
+    }
+}
+
+module.exports.requestInterfaces = requestInterfaces;
+module.exports.interfaces = usableInterfaces;

--- a/server/util/loadInterfaces.js
+++ b/server/util/loadInterfaces.js
@@ -58,7 +58,11 @@ const requestInterfaces = async () => {
     const currentInterface = await config.getValue("interface");
 
     if (!usableInterfaces[currentInterface]) {
-        console.warn(`Interface ${currentInterface} not found. Falling back to default.`);
+        if (!currentInterface) {
+            console.warn("No interface set. Falling back to default.");
+        } else {
+            console.warn(`Interface ${currentInterface} not found. Falling back to default.`);
+        }
         await config.updateValue("interface", Object.keys(usableInterfaces)[0]);
     }
 }

--- a/server/util/providers/parseData.js
+++ b/server/util/providers/parseData.js
@@ -1,19 +1,20 @@
-const roundSpeed = (bytes, elapsed) => {
-    return Math.round((bytes * 8 / elapsed) / 10) / 100;
+const roundSpeed = (bandwidth) => {
+    return Math.round(bandwidth / 1250) / 100;
 }
 
 module.exports.parseOokla = (test) => {
     let ping = Math.round(test.ping.latency);
-    let download = roundSpeed(test.download.bytes, test.download.elapsed);
-    let upload = roundSpeed(test.upload.bytes, test.upload.elapsed);
+    let download = roundSpeed(test.download.bandwidth);
+    let upload = roundSpeed(test.upload.bandwidth);
     let time = Math.round((test.download.elapsed + test.upload.elapsed) / 1000);
 
-    return {ping, download, upload, time};
+    return {ping, download, upload, time, resultId: test.result.id};
 }
 
-module.exports.parseLibre = (test) => ({...test, time: Math.round(test.elapsed / 1000)});
+module.exports.parseLibre = (test) => ({...test, ping: Math.round(test.ping), time: Math.round(test.elapsed / 1000),
+    resultId: null});
 
-module.exports.parseCloudflare = (test) => ({...test, time: Math.round(test.elapsed)});
+module.exports.parseCloudflare = (test) => ({...test, time: Math.round(test.elapsed), resultId: null});
 
 module.exports.parseData = (provider, data) => {
     switch (provider) {

--- a/server/util/speedtest.js
+++ b/server/util/speedtest.js
@@ -1,17 +1,24 @@
 const {spawn} = require('child_process');
+const interfaces = require('../util/loadInterfaces');
+const config = require('../controller/config');
 
 module.exports = async (mode, serverId) => {
     const binaryPath = mode === "ookla" ? './bin/speedtest' + (process.platform === "win32" ? ".exe" : "")
         : './bin/librespeed-cli' + (process.platform === "win32" ? ".exe" : "");
 
+    if (!interfaces.interfaces) throw new Error("No interfaces found");
+
+    const currentInterface = await config.getValue("interface");
+    const interfaceIp = interfaces.interfaces[currentInterface];
+
     const startTime = new Date().getTime();
     let args;
 
     if (mode === "ookla") {
-        args = ['--accept-license', '--accept-gdpr', '--format=json'];
+        args = ['--accept-license', '--accept-gdpr', '--format=json', '--interface=' + currentInterface];
         if (serverId) args.push(`--server-id=${serverId}`);
     } else {
-        args = ['--json', '--duration=5'];
+        args = ['--json', '--duration=5', '--source=' + interfaceIp];
         if (serverId) args.push(`--server=${serverId}`);
     }
 

--- a/server/util/speedtest.js
+++ b/server/util/speedtest.js
@@ -15,7 +15,14 @@ module.exports = async (mode, serverId) => {
     let args;
 
     if (mode === "ookla") {
-        args = ['--accept-license', '--accept-gdpr', '--format=json', '--interface=' + currentInterface];
+        args = ['--accept-license', '--accept-gdpr', '--format=json'];
+
+        if (process.platform === "win32") {
+            args.push('--ip=' + interfaceIp);
+        } else {
+            args.push('--interface=' + currentInterface);
+        }
+
         if (serverId) args.push(`--server-id=${serverId}`);
     } else {
         args = ['--json', '--duration=5', '--source=' + interfaceIp];


### PR DESCRIPTION
# 👨‍💻 Interfaceauswahl hinzugefügt

In manchen Fällen kommt es vor, dass man mehrere Netzwerkanbieter testen möchte. Vielleicht möchte man auch zwischen der Verbindung von dem Heim-LAN und Heim-WLAN unterscheiden. 

Was es auch sein mag, mit dieser PR kann man nun sein Interface auswählen. MySpeed lädt beim Softwarestart alle Interface mit aktiver Internetverbindung in den Arbeitsspeicher und aktualisiert diese Liste jede Stunde.

Das Interface lässt sich dabei in der Providerauswahl einstellen. Diese PR schließt #525

## Screenshots
![image](https://github.com/gnmyt/myspeed/assets/35641351/8b25247e-a240-4f0f-a757-65f9cef3b5c1)


## Änderungen vorgenommen an ...

- [x] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___