### PR TITLE
🕒 Zeitzonen-Problem behoben

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN mv /myspeed/client/build /myspeed
 
 FROM node:18-alpine
 
+RUN apk add --no-cache tzdata
+
 ENV NODE_ENV=production
+ENV TZ=Etc/UTC
 
 WORKDIR /myspeed
 

--- a/client/src/pages/Statistics/charts/PingChart.jsx
+++ b/client/src/pages/Statistics/charts/PingChart.jsx
@@ -18,12 +18,15 @@ const chartOptions = {
 };
 
 const SpeedChart = (props) => {
+    const testTime = localStorage.getItem("testTime") || 1;
     const chartData = {
-        labels: props.labels,
+        labels: testTime < 3 ? props.labels.map((label) => new Date(label).toLocaleTimeString([],
+            {hour: "2-digit", minute: "2-digit"})) : props.labels.slice(1).map((label) =>
+            new Date(label).toLocaleDateString()),
         datasets: [
             {
                 label: t("latest.ping"),
-                data: props.data.ping,
+                data: testTime < 3 ? props.data.ping : props.data.ping.slice(1),
                 borderColor: '#45C65A',
             },
         ],

--- a/client/src/pages/Statistics/charts/SpeedChart.jsx
+++ b/client/src/pages/Statistics/charts/SpeedChart.jsx
@@ -17,11 +17,22 @@ const chartOptions = {
 };
 
 const SpeedChart = (props) => {
+    const testTime = localStorage.getItem("testTime") || 1;
     const chartData = {
-        labels: props.labels,
+        labels: testTime < 3 ? props.labels.map((label) => new Date(label).toLocaleTimeString([],
+            {hour: "2-digit", minute: "2-digit"})) : props.labels.slice(1).map((label) =>
+            new Date(label).toLocaleDateString()),
         datasets: [
-            {label: t("latest.down"), data: props.data.download, borderColor: '#45C65A'},
-            {label: t("latest.up"), data: props.data.upload, borderColor: '#456AC6'},
+            {
+                label: t("latest.down"),
+                data: testTime < 3 ? props.data.download : props.data.download.slice(1),
+                borderColor: '#45C65A'
+            },
+            {
+                label: t("latest.up"),
+                data: testTime < 3 ? props.data.upload : props.data.upload.slice(1),
+                borderColor: '#456AC6'
+            },
         ],
     };
 

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -71,7 +71,7 @@ module.exports.listAverage = async (days) => {
             time: Math.round(avgNumbers["time"]),
             type: "average",
             amount: currentDay.length,
-            created: created.getFullYear() + "-" + (created.getMonth() + 1) + "-" + created.getDate()
+            created: created.toISOString()
         });
     }
 
@@ -124,8 +124,8 @@ module.exports.listStatistics = async (days) => {
         upload: mapFixed(notFailed, "upload"),
         time: mapRounded(notFailed, "time"),
         data,
-        labels: days >= 3 ? avgEntries.map((entry) => new Date(entry.created).toLocaleDateString())
-            : notFailed.map((entry) => new Date(entry.created).toLocaleTimeString([], {hour: "2-digit", minute: "2-digit"}))
+        labels: days >= 3 ? avgEntries.map((entry) => new Date(entry.created).toISOString())
+            : notFailed.map((entry) => new Date(entry.created).toISOString())
     };
 }
 


### PR DESCRIPTION
# 🕒 Zeitzonen-Problem behoben

Wie in #464 beschrieben bestand das Problem darin, dass je nach Ansicht eine Unterschiedliche Zeitzone genutzt wurde (Übersicht lokale Browserzeit und Statistik Serverzeit). Diese PR behebt dabei die folgenden 2 essenziellen Probleme:

1. Teststatistik verwendet nun ebenfalls die Browserzeit. Der Server sendet eine UTC-Zeit, die der Browser umkalkuliert
2. Für Docker-Container wurde Support für die `TZ`-Variable hinzugefügt, damit Cron-Jobs genau dann laufen, wann sie lokal sollen.

## Änderungen vorgenommen an ...

- [x] Server
- [x] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___