### PR TITLE
🔥 Prometheus Endpunkt hinzugefügt 

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -25,6 +25,8 @@ MySpeed ist eine Speedtest-Analyse-Software, welche die Geschwindigkeit deines I
 - 🗄️ Füge mehrere Server direkt zu einer MySpeed-Instanz hinzu
 - 🩺 Es lassen sich Healthchecks konfigurieren, welche dich bei Fehlern oder Ausfällen über E-Mail, Signal, WhatsApp oder Telegram benachrichtigen können
 - 📆 Testergebnisse lassen sich bis zu 30 Tage lang speichern
+- 🔥 Unterstützung für Prometheus und Grafana
+- 🗳️ Wähle zwischen Ookla, LibreSpeed und Cloudflare Speedtest-Servern
 - 💁 Erfahre mehr zu MySpeed auf unserer [Website](https://myspeed.dev)
 
 ### ⬇️ Installation

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ MySpeed is a speed test analysis software that records your internet speed for u
 - 🗄️ Add multiple servers directly to a MySpeed instance
 - 🩺 Configure health checks to notify you via email, Signal, WhatsApp, or Telegram in case of errors or downtime
 - 📆 Test results can be stored for up to 30 days
+- 🔥 Support for Prometheus and Grafana
+- 🗳️ Choose between Ookla, LibreSpeed and Cloudflare speed test servers
 - 💁 Learn more about MySpeed on our [website](https://myspeed.dev)
 
 ### ⬇️ Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.19.2",
         "mysql2": "^3.9.7",
         "node-schedule": "^2.1.1",
+        "prom-client": "^15.1.2",
         "sequelize": "^6.37.3",
         "sqlite3": "^5.1.7",
         "tmp": "^0.2.3"
@@ -153,6 +154,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -409,6 +418,11 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/bl": {
       "version": "1.2.3",
@@ -2504,6 +2518,18 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prom-client": {
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.2.tgz",
+      "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -3281,6 +3307,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -3691,6 +3725,11 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3882,6 +3921,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "bl": {
       "version": "1.2.3",
@@ -5438,6 +5482,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "prom-client": {
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.2.tgz",
+      "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
+      "requires": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -5999,6 +6052,14 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
       }
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^4.19.2",
     "mysql2": "^3.9.7",
     "node-schedule": "^2.1.1",
+    "prom-client": "^15.1.2",
     "sequelize": "^6.37.3",
     "sqlite3": "^5.1.7",
     "tmp": "^0.2.3"

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -145,3 +145,10 @@ module.exports.removeOld = async () => {
     });
     return true;
 }
+
+module.exports.getLatest = async () => {
+    let latest = await tests.findOne({order: [["created", "DESC"]]});
+    if (latest.error === null) delete latest.error;
+    if (latest.resultId === null) delete latest.resultId;
+    return latest;
+}

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -152,3 +152,11 @@ module.exports.getLatest = async () => {
     if (latest.resultId === null) delete latest.resultId;
     return latest;
 }
+
+module.exports.getLatest = async () => {
+    let latest = await tests.findOne({order: [["created", "DESC"]]});
+    if (latest === null) return undefined;
+    if (latest.error === null) delete latest.error;
+    if (latest.resultId === null) delete latest.resultId;
+    return latest;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ app.use("/api/storage", require('./routes/storage'));
 app.use("/api/recommendations", require('./routes/recommendations'));
 app.use("/api/nodes", require('./routes/nodes'));
 app.use("/api/integrations", require('./routes/integrations'));
+app.use("/api/prometheus", require('./routes/prometheus'));
 app.use("/api*", (req, res) => res.status(404).json({message: "Route not found"}));
 
 if (process.env.NODE_ENV === 'production') {

--- a/server/routes/prometheus.js
+++ b/server/routes/prometheus.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const app = express.Router();
+const testController = require('../controller/speedtests');
+const promClient = require('prom-client');
+const config = require('../controller/config');
+const bcrypt = require('bcrypt');
+
+const pingGauge = new promClient.Gauge({name: 'myspeed_ping', help: 'Current ping in ms'});
+const downloadGauge = new promClient.Gauge({name: 'myspeed_download', help: 'Current download speed in Mbps'});
+const uploadGauge = new promClient.Gauge({name: 'myspeed_upload', help: 'Current upload speed in Mbps'});
+const currentServerGauge = new promClient.Gauge({name: 'myspeed_server', help: 'Current server ID',});
+const timeGauge = new promClient.Gauge({name: 'myspeed_time', help: 'Time of the test'});
+
+app.get('/metrics', async (req, res) => {
+    let passwordHash = await config.getValue("password");
+
+    if (passwordHash !== "none") {
+        if (!req.headers.authorization || req.headers.authorization.indexOf('Basic ') === -1) {
+            res.setHeader('WWW-Authenticate', 'Basic realm="User Visible Realm"');
+            return res.status(401).end('Unauthorized');
+        }
+
+        const base64Credentials =  req.headers.authorization.split(' ')[1];
+        const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii');
+        const [username, password] = credentials.split(':');
+
+        if (username !== "prometheus" || !bcrypt.compareSync(password, passwordHash)) {
+            res.setHeader('WWW-Authenticate', 'Basic realm="User Visible Realm"');
+            return res.status(401).end('Unauthorized');
+        }
+    }
+
+    const latest = await testController.getLatest();
+    if (!latest) return res.status(500).end('No test found');
+
+    pingGauge.set(latest.ping);
+    downloadGauge.set(latest.download);
+    uploadGauge.set(latest.upload);
+    currentServerGauge.set(latest.serverId);
+    timeGauge.set(latest.time);
+
+    res.set('Content-Type', promClient.register.contentType);
+    res.end(await promClient.register.metrics());
+});
+
+module.exports = app;

--- a/server/routes/prometheus.js
+++ b/server/routes/prometheus.js
@@ -33,6 +33,9 @@ app.get('/metrics', async (req, res) => {
     const latest = await testController.getLatest();
     if (!latest) return res.status(500).end('No test found');
 
+    if (latest.error || latest.ping === -1)
+        return res.status(500).end('Error in the latest test');
+
     pingGauge.set(latest.ping);
     downloadGauge.set(latest.download);
     uploadGauge.set(latest.upload);


### PR DESCRIPTION
# 🔥 Prometheus Endpunkt hinzugefügt 

MySpeed erhält nun wie gewünscht einen Prometheus-Endpunkt. Dieser zeigt dann immer die Daten des letzten Tests an. Der Endpunkt zeigt dabei folgende Werte an: `Download`, `Upload`, `Ping`, `Time`, `Current Server`. Dies schließt #515

Hier eine Beispiel-Konfiguration für MySpeed in der `prometheus.yml`:

```yml
  - job_name: 'myspeed'
    scrape_interval: 1m # Je nach Testzeitraum anpassen
    scrape_timeout: 8s
    metrics_path: /api/prometheus/metrics
    basic_auth:
      username: prometheus
      password: dein-passwort # Nur notwendig, wenn ein Passwort in der Weboberfläche gesetzt wurde
    static_configs:
      - targets: ['localhost:5216']
```

Wichtig ist es, das `scrape_interval` anzupassen. Weiß man bereits vorher, dass man nur automatisierte Tests laufen lässt und diese auf jede Stunde gestellt hat, reicht es hier aus, `1h` festzulegen. So spart man sich die Bandbreite und unnötige Duplikate. Macht man öfters manuelle Tests und möchte sicher gehen, dass diese angezeigt werden, kann man hier variieren.

## Screenshots

![image](https://github.com/gnmyt/myspeed/assets/35641351/7c8a1a08-056e-4c25-8a31-61b88bb0d60d)


## Änderungen vorgenommen an ...

- [x] Server
- [ ] Client
- [ ] Dokumentation
- [ ] Sonstiges: ___