### PR TITLE
🐛 Date in 'Last test' dialog scrambled

### DIFF
--- a/client/src/pages/Home/components/LatestTest/utils/dialogs.jsx
+++ b/client/src/pages/Home/components/LatestTest/utils/dialogs.jsx
@@ -9,8 +9,9 @@ export const uploadInfo = () => ({title: t("info.up.title"), description: t("inf
 
 export const latestTestInfo = (latest) => ({
     title: t("info.latest.title"),
-    description: latest.created ? <Trans components={{Bold: <span className="dialog-value"/>}} values={{date: new Date(latest.created).toLocaleDateString(),
-                            time: new Date(latest.created).toLocaleTimeString(undefined, {hour: "2-digit", minute: "2-digit"})}}>
+    description: latest.created ? <Trans shouldUnescape components={{Bold: <span className="dialog-value"/>}}
+                                         values={{date: new Date(latest.created).toLocaleDateString(),
+                                             time: new Date(latest.created).toLocaleTimeString(undefined, {hour: "2-digit", minute: "2-digit"})}}>
         info.latest.description</Trans> : t("test.no_latest"),
     buttonText: t("dialog.okay")
 });


### PR DESCRIPTION
## 🐛 Date in 'Last test' dialog scrambled

In the english version of MySpeed, where date is formatted with "/", the date is not displayed correctly.
This PR fixes this issue by disabling the escaping of the characters.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #761 