### PR TITLE
⬆️ Back to top button

### DIFF
--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -389,5 +389,8 @@
         "send_config_updates": "Send configuration updates"
       }
     }
+  },
+  "common": {
+    "back_to_top": "Back to top"
   }
 }

--- a/client/src/common/components/StorageDialog/styles.sass
+++ b/client/src/common/components/StorageDialog/styles.sass
@@ -4,7 +4,7 @@
   display: flex
   margin-left: 0.5rem
   margin-right: 0.5rem
-  gap: 1rem
+  gap: 2rem
   width: 45rem
   margin-top: 1rem
   height: 14rem
@@ -21,7 +21,7 @@
   gap: 0.5rem
   user-select: none
   overflow-x: hidden
-  overflow-y: scroll
+  overflow-y: hidden
 
 .storage-tab
   display: flex
@@ -86,6 +86,4 @@
   .storage-top
     flex-direction: row
     justify-content: center
-    overflow-x: scroll
-    overflow-y: hidden
     gap: 0.5rem

--- a/client/src/common/styles/default.sass
+++ b/client/src/common/styles/default.sass
@@ -9,14 +9,26 @@ body, html
   font-weight: 700
 
 ::-webkit-scrollbar
-  width: 13px
+  width: 14px
+  background: $background
+
+::-webkit-scrollbar-track
+  background: $background
+  border-radius: 10px
+  margin: 5px
 
 ::-webkit-scrollbar-thumb
-  background: $darker-gray
+  background: $light-gray
   border-radius: 10px
+  border: 2px solid $background
+  min-height: 40px
 
 ::-webkit-scrollbar-thumb:hover
-  background: $dark-gray
+  background: $white
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3)
+
+::-webkit-scrollbar-thumb:active
+  background: $subtext
 
 .speedtest-icon
   font-size: 26pt

--- a/client/src/pages/Home/components/TestArea/TestAreaComponent.jsx
+++ b/client/src/pages/Home/components/TestArea/TestAreaComponent.jsx
@@ -6,12 +6,15 @@ import Speedtest from "../Speedtest";
 import {getIconBySpeed} from "@/common/utils/TestUtil";
 import "./styles.sass";
 import {t} from "i18next";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faArrowUp} from "@fortawesome/free-solid-svg-icons";
 
 const TestArea = () => {
     const config = useContext(ConfigContext)[0];
     const {speedtests, loadMoreTests, loading, hasMore} = useContext(SpeedtestContext);
     const [stickyDate, setStickyDate] = useState(null);
     const [showStickyDate, setShowStickyDate] = useState(false);
+    const [showBackToTop, setShowBackToTop] = useState(false);
     const [initialLoadComplete, setInitialLoadComplete] = useState(false);
     const containerRef = useRef();
     const lastElementRef = useRef();
@@ -39,6 +42,9 @@ const TestArea = () => {
 
         const shouldShow = scrollTop > 50;
         setShowStickyDate(shouldShow);
+
+        const shouldShowBackToTop = scrollTop > 300;
+        setShowBackToTop(shouldShowBackToTop);
 
         const windowHeight = window.innerHeight;
         const documentHeight = Math.max(document.body.scrollHeight, document.body.offsetHeight,
@@ -70,6 +76,12 @@ const TestArea = () => {
             }
         }
     }, [speedtests, stickyDate, hasMore, loading, loadMoreTests]);
+
+    const scrollToTop = useCallback(() => {
+        window.scrollTo({top: 0, behavior: 'smooth'});
+        document.documentElement.scrollTo({top: 0, behavior: 'smooth'});
+        document.body.scrollTo({top: 0, behavior: 'smooth'});
+    }, []);
 
     useEffect(() => {
         let ticking = false;
@@ -122,6 +134,11 @@ const TestArea = () => {
                 <div className="floating-date-indicator">
                     <span>{stickyDate}</span>
                 </div>, document.body)}
+
+            {showBackToTop && createPortal(
+                <button className="back-to-top-button" onClick={scrollToTop} aria-label={t("common.back_to_top")}>
+                    <FontAwesomeIcon icon={faArrowUp}/>
+                </button>, document.body)}
 
             <div className="speedtest-area" ref={containerRef}>
                 {speedtests.map((test, index) => {

--- a/client/src/pages/Home/components/TestArea/styles.sass
+++ b/client/src/pages/Home/components/TestArea/styles.sass
@@ -55,6 +55,56 @@
     span
       font-size: 13px
 
+  .back-to-top-button
+    bottom: 20px
+    left: 20px
+    width: 48px
+    height: 48px
+    
+    svg
+      width: 20px
+      height: 20px
+
 @media (max-width: 475px)
   .error-text
     width: 20rem
+
+.back-to-top-button
+  position: fixed
+  bottom: 30px
+  left: 30px
+  z-index: 50
+  width: 56px
+  height: 56px
+  background: $dark-gray
+  backdrop-filter: blur(10px)
+  border: $light-gray 2px solid
+  border-radius: 50%
+  color: $white
+  cursor: pointer
+  display: flex
+  align-items: center
+  justify-content: center
+  box-shadow: 0 0 15px rgba($light-gray, 0.5)
+  transition: all 0.3s ease
+  animation: slideInUp 0.3s ease-out
+  
+  &:hover
+    transform: translateY(-3px)
+    box-shadow: 0 4px 20px rgba($light-gray, 0.7)
+    background: $light-gray
+    
+  &:active
+    transform: translateY(-1px)
+    
+  svg
+    width: 24px
+    height: 24px
+    
+@keyframes slideInUp
+  from
+    opacity: 0
+    transform: translateY(20px)
+  to
+    opacity: 1
+    transform: translateY(0)


### PR DESCRIPTION
## ⬆️ Back to top button

The new redesign comes with some challenges. Implementing infinite scrolling means that there will be many elements rendered on the page, which also makes it more complicated to navigate up again.

This PR implements a simple button to just jump back to the top of the page.

![Screenshot_20250611_211307](https://github.com/user-attachments/assets/6a172aab-c629-4ab8-973e-6a11775111d7)


## 🚀 Changes made to ...

- [ ] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none