### PR TITLE
🛡️ HTTPS Support

### DIFF
--- a/docs/.vitepress/config/de.mjs
+++ b/docs/.vitepress/config/de.mjs
@@ -17,6 +17,7 @@ export const de = defineConfig({
                 text: 'Anleitungen',
                 items: [
                     { text: 'Einrichten eines Reverse Proxys', link: 'de/guides/reverse-proxy' },
+                    { text: 'HTTPS einrichten', link: 'de/guides/https' },
                     { text: 'Statistiken & Diagramme', link: 'de/guides/statistics' }
                 ]
             },

--- a/docs/.vitepress/config/en.mjs
+++ b/docs/.vitepress/config/en.mjs
@@ -17,6 +17,7 @@ export const en = defineConfig({
         text: 'Guides',
         items: [
           { text: 'Configuring a Reverse Proxy', link: 'guides/reverse-proxy' },
+          { text: 'Setting up HTTPS', link: 'guides/https' },
           { text: 'Statistics & Charts', link: 'guides/statistics' }
         ]
       },

--- a/docs/de/guides/https.md
+++ b/docs/de/guides/https.md
@@ -1,0 +1,114 @@
+# HTTPS einrichten
+
+::: tip Warum HTTPS verwenden?
+HTTPS verschlüsselt die Verbindung zwischen deinem Browser und MySpeed und schützt deine Daten vor dem Abfangen.
+Dies ist besonders wichtig, wenn du über ein Netzwerk oder das Internet auf MySpeed zugreifst.
+:::
+
+## Übersicht
+
+MySpeed unterstützt HTTPS nativ ohne einen Reverse Proxy zu benötigen. Lege einfach deine SSL-Zertifikate im Verzeichnis `data/certs` ab, und MySpeed startet automatisch einen HTTPS-Server.
+
+## Konfiguration
+
+### Umgebungsvariablen
+
+| Variable | Standard | Beschreibung |
+|----------|----------|--------------|
+| `HTTPS_PORT` | `5217` | Der Port für den HTTPS-Server |
+
+### Zertifikatsdateien
+
+Lege deine SSL-Zertifikate im Verzeichnis `data/certs` ab:
+
+- `cert.pem` - Dein SSL-Zertifikat
+- `key.pem` - Dein privater Schlüssel
+
+Die Ordnerstruktur sollte so aussehen:
+
+```
+MySpeed/
+├── data/
+│   ├── certs/
+│   │   ├── cert.pem
+│   │   └── key.pem
+│   └── ...
+└── ...
+```
+
+## Eigene Zertifikate verwenden
+
+Wenn du bereits SSL-Zertifikate hast (z.B. von Let's Encrypt oder einer Zertifizierungsstelle), kopiere sie in das Verzeichnis `data/certs`:
+
+```sh
+cp /pfad/zu/deinem/zertifikat.pem /pfad/zu/myspeed/data/certs/cert.pem
+cp /pfad/zu/deinem/privater-schluessel.pem /pfad/zu/myspeed/data/certs/key.pem
+```
+
+## Selbstsigniertes Zertifikat erstellen
+
+Für Tests oder den internen Gebrauch kannst du ein selbstsigniertes Zertifikat erstellen:
+
+```sh
+openssl req -x509 -newkey rsa:4096 \
+  -keyout data/certs/key.pem \
+  -out data/certs/cert.pem \
+  -sha256 -days 365 -nodes \
+  -subj "/C=DE/ST=Bundesland/L=Stadt/O=Organisation/OU=Abteilung/CN=localhost"
+```
+
+::: warning Selbstsignierte Zertifikate
+Selbstsignierte Zertifikate zeigen eine Sicherheitswarnung im Browser an. Das ist bei selbstsignierten Zertifikaten normal.
+Für den Produktiveinsatz empfehlen wir Zertifikate von einer vertrauenswürdigen Zertifizierungsstelle wie Let's Encrypt.
+:::
+
+## Let's Encrypt Zertifikate verwenden
+
+Wenn du Let's Encrypt mit certbot verwendest, werden deine Zertifikate normalerweise in `/etc/letsencrypt/live/deine-domain.de/` gespeichert. Du kannst sie entweder kopieren oder verlinken:
+
+```sh
+# Zertifikate kopieren
+sudo cp /etc/letsencrypt/live/deine-domain.de/fullchain.pem /pfad/zu/myspeed/data/certs/cert.pem
+sudo cp /etc/letsencrypt/live/deine-domain.de/privkey.pem /pfad/zu/myspeed/data/certs/key.pem
+
+# Stelle sicher, dass MySpeed sie lesen kann
+sudo chown $USER:$USER /pfad/zu/myspeed/data/certs/*.pem
+```
+
+::: tip Zertifikatserneuerung
+Denke daran, deine Zertifikate im Verzeichnis `data/certs` zu aktualisieren, wenn sie erneuert werden.
+Du kannst dies mit einem Post-Renewal-Hook in certbot automatisieren.
+:::
+
+## Überprüfen ob HTTPS funktioniert
+
+Nachdem du deine Zertifikate abgelegt und MySpeed gestartet hast, solltest du in der Konsole sehen:
+
+```
+Server listening on port 5216
+HTTPS server listening on port 5217
+```
+
+Du kannst dann auf MySpeed zugreifen über:
+- HTTP: `http://localhost:5216`
+- HTTPS: `https://localhost:5217`
+
+## Docker-Konfiguration
+
+Bei Verwendung von Docker mountest du das Zertifikatsverzeichnis:
+
+```yaml
+version: "3"
+services:
+  myspeed:
+    image: germannewsmaker/myspeed
+    ports:
+      - "5216:5216"
+      - "5217:5217"  # HTTPS-Port
+    volumes:
+      - /pfad/zu/myspeed:/myspeed/data
+      # Zertifikate befinden sich in /pfad/zu/myspeed/certs/
+    environment:
+      - HTTPS_PORT=5217  # Optional, 5217 ist Standard
+```
+

--- a/docs/en/guides/https.md
+++ b/docs/en/guides/https.md
@@ -1,0 +1,114 @@
+# Setting up HTTPS
+
+::: tip Why use HTTPS?
+HTTPS encrypts the connection between your browser and MySpeed, protecting your data from being intercepted.
+This is especially important if you access MySpeed over a network or the internet.
+:::
+
+## Overview
+
+MySpeed supports HTTPS natively without requiring a reverse proxy. Simply place your SSL certificates in the `data/certs` directory, and MySpeed will automatically start an HTTPS server.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HTTPS_PORT` | `5217` | The port for the HTTPS server |
+
+### Certificate Files
+
+Place your SSL certificates in the `data/certs` directory:
+
+- `cert.pem` - Your SSL certificate
+- `key.pem` - Your private key
+
+The folder structure should look like this:
+
+```
+MySpeed/
+├── data/
+│   ├── certs/
+│   │   ├── cert.pem
+│   │   └── key.pem
+│   └── ...
+└── ...
+```
+
+## Using Your Own Certificates
+
+If you already have SSL certificates (e.g., from Let's Encrypt or a certificate authority), copy them to the `data/certs` directory:
+
+```sh
+cp /path/to/your/certificate.pem /path/to/myspeed/data/certs/cert.pem
+cp /path/to/your/private-key.pem /path/to/myspeed/data/certs/key.pem
+```
+
+## Generating a Self-Signed Certificate
+
+For testing or internal use, you can generate a self-signed certificate:
+
+```sh
+openssl req -x509 -newkey rsa:4096 \
+  -keyout data/certs/key.pem \
+  -out data/certs/cert.pem \
+  -sha256 -days 365 -nodes \
+  -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=localhost"
+```
+
+::: warning Self-Signed Certificates
+Self-signed certificates will show a security warning in browsers. This is normal for self-signed certificates.
+For production use, we recommend using certificates from a trusted certificate authority like Let's Encrypt.
+:::
+
+## Using Let's Encrypt Certificates
+
+If you're using Let's Encrypt with certbot, your certificates are typically stored in `/etc/letsencrypt/live/your-domain.com/`. You can either copy or symlink them:
+
+```sh
+# Copy the certificates
+sudo cp /etc/letsencrypt/live/your-domain.com/fullchain.pem /path/to/myspeed/data/certs/cert.pem
+sudo cp /etc/letsencrypt/live/your-domain.com/privkey.pem /path/to/myspeed/data/certs/key.pem
+
+# Make sure MySpeed can read them
+sudo chown $USER:$USER /path/to/myspeed/data/certs/*.pem
+```
+
+::: tip Certificate Renewal
+Remember to update your certificates in the `data/certs` directory when they are renewed.
+You can automate this with a post-renewal hook in certbot.
+:::
+
+## Verifying HTTPS is Working
+
+After placing your certificates and starting MySpeed, you should see in the console:
+
+```
+Server listening on port 5216
+HTTPS server listening on port 5217
+```
+
+You can then access MySpeed via:
+- HTTP: `http://localhost:5216`
+- HTTPS: `https://localhost:5217`
+
+## Docker Configuration
+
+When using Docker, mount the certificates directory:
+
+```yaml
+version: "3"
+services:
+  myspeed:
+    image: germannewsmaker/myspeed
+    ports:
+      - "5216:5216"
+      - "5217:5217"  # HTTPS port
+    volumes:
+      - /path/to/myspeed:/myspeed/data
+      # Certificates will be in /path/to/myspeed/certs/
+    environment:
+      - HTTPS_PORT=5217  # Optional, 5217 is default
+```
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import path from 'node:path';
 import fs from 'node:fs';
+import https from 'node:https';
 import { fileURLToPath } from 'node:url';
 import * as timerTask from './tasks/timer.js';
 import * as integrationTask from './tasks/integrations.js';
@@ -34,6 +35,13 @@ const app = express();
 app.disable('x-powered-by');
 
 const port = process.env.SERVER_PORT || 5216;
+const httpsPort = process.env.HTTPS_PORT || 5217;
+
+const certsDir = path.join(process.cwd(), 'data', 'certs');
+const certPath = path.join(certsDir, 'cert.pem');
+const keyPath = path.join(certsDir, 'key.pem');
+
+const hasSSLCerts = () => fs.existsSync(certPath) && fs.existsSync(keyPath);
 
 process.on('uncaughtException', err => errorHandler(err));
 
@@ -87,6 +95,21 @@ const run = async () => {
     }
 
     app.listen(port, () => console.log(`Server listening on port ${port}`));
+
+    if (hasSSLCerts()) {
+        try {
+            const sslOptions = {
+                cert: fs.readFileSync(certPath),
+                key: fs.readFileSync(keyPath)
+            };
+
+            https.createServer(sslOptions, app).listen(httpsPort, () =>
+                console.log(`HTTPS server listening on port ${httpsPort}`)
+            );
+        } catch (err) {
+            console.error(`Failed to start HTTPS server: ${err.message}`);
+        }
+    }
 }
 
 db.authenticate().then(() => {

--- a/server/util/createFolders.js
+++ b/server/util/createFolders.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 const baseDir = process.cwd();
 
-const neededFolder = ["data", "bin", "data/logs", "data/servers"];
+const neededFolder = ["data", "bin", "data/logs", "data/servers", "data/certs"];
 
 neededFolder.forEach(folder => {
     const fullPath = path.join(baseDir, folder);


### PR DESCRIPTION
## 🛡️ HTTPS Support

This PR adds support for a separate HTTPS port. It will be automatically enabled if a certificate has been provided in `data/certs` and runs on port 5217 if not configured using `HTTPS_PORT`.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [x] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes #1057