### PR TITLE
fix: restore macOS startup support

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -34,6 +34,13 @@ MySpeed ist eine Speedtest-Analyse-Software, welche die Geschwindigkeit deines I
 - **🐧 Anleitung für [Linux](https://docs.myspeed.dev/setup/linux)**
 - **🪟 Anleitung für [Windows](https://docs.myspeed.dev/setup/windows)**
 
+### 🍎 macOS-Unterstützung
+
+- MySpeed laesst sich jetzt unter macOS fuer lokale Entwicklung und beim Start aus dem Quellcode erfolgreich ausfuehren.
+- Der macOS-Startpfad beruecksichtigt jetzt sowohl Apple Silicon als auch Intel Macs bei Nutzung des integrierten Ookla-CLI-Bootstraps.
+- Wenn du aus dem Quellcode startest, verwende `deno task dev` oder `deno run --allow-all server/index.js` im Repository-Root.
+- Die Installationsanleitungen oben bleiben weiterhin auf Linux und Windows fokussiert.
+
 ### 📸 Beispiel-Screenshots
 
 #### Startseite (Listen-Ansicht)
@@ -57,7 +64,7 @@ MySpeed ist eine Speedtest-Analyse-Software, welche die Geschwindigkeit deines I
 
 ## Überzeugt?
 
-Cool, dann lass uns loslegen! Die Installationsanleitung für Linux (und Windows) findest du oben unter Installation.
+Cool, dann lass uns loslegen! Die Installationsanleitungen fuer Linux und Windows findest du oben unter Installation, den Hinweis zum Start unter macOS aus dem Quellcode direkt darueber.
 
 ## Lizenz
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ MySpeed is a speed test analysis software that records your internet speed for u
 - **🐧 Guide for [Linux](https://docs.myspeed.dev/setup/linux)**
 - **🪟 Guide for [Windows](https://docs.myspeed.dev/setup/windows)**
 
+### 🍎 macOS Support
+
+- MySpeed can now start on macOS for local development and source-based setups.
+- The macOS startup path now includes code-path support for both Apple Silicon and Intel Macs when using the built-in Ookla CLI bootstrap.
+- If you run from source, start the app with `deno task dev` or `deno run --allow-all server/index.js` from the repository root.
+- The one-click installation guides above are still Linux and Windows focused.
+
 ### 📸 Example Screenshots
 
 #### Homepage (List View)
@@ -57,7 +64,7 @@ MySpeed is a speed test analysis software that records your internet speed for u
 
 ## Convinced?
 
-Great, let's get started! You can find the installation instructions for Linux (and Windows) at the top under Installation.
+Great, let's get started! You can find the installation instructions for Linux and Windows at the top under Installation, and the macOS source-based startup note right above.
 
 ## License
 

--- a/server/config/binaries.js
+++ b/server/config/binaries.js
@@ -1,7 +1,8 @@
 export const ooklaVersion = "1.2.0";
 export const ooklaList = [
     // MacOS
-    {os: 'darwin', arch: 'x64', suffix: 'macosx-x86_64.tgz'},
+    {os: 'darwin', arch: 'x64', suffix: 'macosx-universal.tgz'},
+    {os: 'darwin', arch: 'arm64', suffix: 'macosx-universal.tgz'},
 
     // Windows
     {os: 'win32', arch: 'x64', suffix: 'win64.zip'},

--- a/server/config/binaries.test.js
+++ b/server/config/binaries.test.js
@@ -1,0 +1,16 @@
+import { ooklaList } from './binaries.js';
+
+Deno.test('ooklaList uses the universal macOS archive for x64 and arm64', () => {
+    const macEntries = ooklaList
+        .filter((entry) => entry.os === 'darwin' && (entry.arch === 'x64' || entry.arch === 'arm64'))
+        .sort((a, b) => a.arch.localeCompare(b.arch));
+
+    const expected = [
+        {os: 'darwin', arch: 'arm64', suffix: 'macosx-universal.tgz'},
+        {os: 'darwin', arch: 'x64', suffix: 'macosx-universal.tgz'}
+    ];
+
+    if (JSON.stringify(macEntries) !== JSON.stringify(expected)) {
+        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(macEntries)}`);
+    }
+});

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import * as timerTask from './tasks/timer.js';
 import * as integrationTask from './tasks/integrations.js';
 import './util/createFolders.js';
-import './util/loadServers.js';
+import { loadServers } from './util/loadServers.js';
 import errorHandler from './util/errorHandler.js';
 import errorMiddleware from './middlewares/error.js';
 import configRoutes from './routes/config.js';
@@ -34,6 +34,8 @@ const app = express();
 
 app.disable('x-powered-by');
 
+const clientPublicPath = path.join(process.cwd(), 'client', 'public');
+
 const port = process.env.SERVER_PORT || 5216;
 const httpsPort = process.env.HTTPS_PORT || 5217;
 
@@ -47,6 +49,10 @@ process.on('uncaughtException', err => errorHandler(err));
 
 app.use(express.json({ limit: '50mb' }));
 app.use(errorMiddleware);
+
+if (fs.existsSync(clientPublicPath)) {
+    app.use(express.static(clientPublicPath));
+}
 
 app.use("/api/config", configRoutes);
 app.use("/api/speedtests", speedtestsRoutes);
@@ -82,6 +88,8 @@ const run = async () => {
     await requestInterfaces();
     setInterval(() => requestInterfaces(), 3600000);
 
+    await loadServers();
+
     if (process.env.PREVIEW_MODE !== "true") await loadCli();
 
     await config.insertDefaults();
@@ -114,7 +122,7 @@ const run = async () => {
 
 db.authenticate().then(() => {
     console.log("Successfully connected to the database " + (process.env.DB_TYPE === "mysql" ? "server" : "file"));
-    run().then(undefined);
+    return run().catch(errorHandler);
 }).catch(err => {
     console.error("Could not open the database file. Maybe it is damaged?: " + err.message);
     process.exit(111);

--- a/server/templates/env.html
+++ b/server/templates/env.html
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
     <meta name="viewport" content="width=device-width"/>
-    <link rel="icon" href="https://i.imgur.com/aCmA6rH.png" type="image/png"/>
+    <link rel="icon" href="/assets/img/logo192.png" type="image/png"/>
     <title>MySpeed [Dev Mode]</title>
     <style type="text/css">
         body, html {
@@ -76,7 +76,7 @@
 <body>
 
 <div class="logo">
-    <img src="https://i.imgur.com/aCmA6rH.png" alt="MySpeed Logo"/>
+    <img src="/assets/img/logo.png" alt="MySpeed Logo"/>
     <h1>MySpeed <span>Dev Mode</span></h1>
 </div>
 

--- a/server/templates/env.test.js
+++ b/server/templates/env.test.js
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+
+const templatePath = new URL('./env.html', import.meta.url);
+
+Deno.test('dev mode template uses a local logo asset instead of an external imgur URL', () => {
+    const template = fs.readFileSync(templatePath, 'utf8');
+
+    if (template.includes('https://i.imgur.com/aCmA6rH.png')) {
+        throw new Error('Expected dev mode template to avoid the external Imgur logo URL');
+    }
+
+    if (!template.includes('/assets/img/logo.png')) {
+        throw new Error('Expected dev mode template to reference /assets/img/logo.png');
+    }
+});

--- a/server/util/loadServers.js
+++ b/server/util/loadServers.js
@@ -1,45 +1,75 @@
-import axios from 'axios';
 import fs from 'node:fs';
 
-// Load servers from ookla
-if (!fs.existsSync("data/servers/ookla.json")) {
-    let servers = {};
-    try {
-        axios.get("https://www.speedtest.net/api/js/servers?limit=20")
-            .then(res => res.data)
-            .then(data => {
-                data?.forEach(row => {
-                    servers[row.id] = row.name + " (" + row.distance + "km)";
-                });
+const ooklaPath = 'data/servers/ookla.json';
+const librePath = 'data/servers/librespeed.json';
 
-                try {
-                    fs.writeFileSync("data/servers/ookla.json", JSON.stringify(servers, null, 4));
-                } catch (e) {
-                    console.error("Could not save servers file");
-                }
-            });
-    } catch (e) {
-        console.error("Could not get servers");
+const providerConfigs = {
+    ookla: {
+        cachePath: ooklaPath,
+        errorName: 'Ookla',
+        url: 'https://www.speedtest.net/api/js/servers?limit=20',
+        mapRow: (row) => [row.id, `${row.name} (${row.distance}km)`]
+    },
+    librespeed: {
+        cachePath: librePath,
+        errorName: 'LibreSpeed',
+        url: 'https://librespeed.org/backend-servers/servers.php',
+        mapRow: (row) => [row.id, row.name]
     }
-}
+};
 
-// Load servers from librespeed
-if (!fs.existsSync("data/servers/librespeed.json")) {
-    let servers = {};
-    try {
-        axios.get("https://librespeed.org/backend-servers/servers.php")
-            .then(res => res.data)
-            .then(data => {
-                data?.forEach(row => {
-                    servers[row.id] = row.name;
-                });
-                try {
-                    fs.writeFileSync("data/servers/librespeed.json", JSON.stringify(servers, null, 4));
-                } catch (e) {
-                    console.error("Could not save servers file");
-                }
-            });
-    } catch (e) {
-        console.error("Could not get servers");
+const buildServersMap = (rows, mapRow) => {
+    const servers = {};
+
+    rows?.forEach((row) => {
+        const [id, value] = mapRow(row);
+        servers[id] = value;
+    });
+
+    return servers;
+};
+
+const buildResponseError = (response) => {
+    const statusText = response.statusText ? ` ${response.statusText}` : '';
+
+    return new Error(`Request failed with status ${response.status}${statusText}`);
+};
+
+const loadProviderServers = async ({cachePath, errorName, fetchFn, fsModule, mapRow, url}) => {
+    if (fsModule.existsSync(cachePath)) {
+        return false;
     }
-}
+
+    try {
+        const response = await fetchFn(url);
+
+        if (!response.ok) {
+            throw buildResponseError(response);
+        }
+
+        const servers = buildServersMap(await response.json(), mapRow);
+
+        fsModule.writeFileSync(cachePath, JSON.stringify(servers, null, 4));
+
+        return true;
+    } catch (error) {
+        throw new Error(`Could not load ${errorName} servers: ${error.message}`, {cause: error});
+    }
+};
+
+export const loadOoklaServers = async ({fetchFn = globalThis.fetch, fsModule = fs} = {}) => loadProviderServers({
+    ...providerConfigs.ookla,
+    fsModule,
+    fetchFn
+});
+
+export const loadLibreServers = async ({fetchFn = globalThis.fetch, fsModule = fs} = {}) => loadProviderServers({
+    ...providerConfigs.librespeed,
+    fsModule,
+    fetchFn
+});
+
+export const loadServers = async ({fetchFn = globalThis.fetch, fsModule = fs} = {}) => {
+    await loadOoklaServers({fetchFn, fsModule});
+    await loadLibreServers({fetchFn, fsModule});
+};

--- a/server/util/loadServers.test.js
+++ b/server/util/loadServers.test.js
@@ -1,0 +1,183 @@
+import { loadLibreServers, loadOoklaServers } from './loadServers.js';
+
+Deno.test('loadOoklaServers skips fetch when cache file already exists', async () => {
+    let fetchCalls = 0;
+    let writeCalls = 0;
+
+    await loadOoklaServers({
+        fetchFn: async () => {
+            fetchCalls += 1;
+            return {
+                ok: true,
+                json: async () => []
+            };
+        },
+        fsModule: {
+            existsSync: (filePath) => {
+                if (filePath !== 'data/servers/ookla.json') {
+                    throw new Error(`Unexpected cache path: ${filePath}`);
+                }
+
+                return true;
+            },
+            writeFileSync: () => {
+                writeCalls += 1;
+            }
+        }
+    });
+
+    if (fetchCalls !== 0) {
+        throw new Error(`Expected no fetch when cache exists, got ${fetchCalls} calls`);
+    }
+
+    if (writeCalls !== 0) {
+        throw new Error(`Expected no writes when cache exists, got ${writeCalls} calls`);
+    }
+});
+
+Deno.test('loadOoklaServers fetches and writes the expected cache file', async () => {
+    let requestedUrl;
+    let writtenPath;
+    let writtenContent;
+
+    await loadOoklaServers({
+        fetchFn: async (url) => {
+            requestedUrl = url;
+
+            return {
+                ok: true,
+                json: async () => [
+                    {id: '123', name: 'Example Ookla', distance: 27}
+                ]
+            };
+        },
+        fsModule: {
+            existsSync: () => false,
+            writeFileSync: (filePath, content) => {
+                writtenPath = filePath;
+                writtenContent = content;
+            }
+        }
+    });
+
+    if (requestedUrl !== 'https://www.speedtest.net/api/js/servers?limit=20') {
+        throw new Error(`Unexpected Ookla URL: ${requestedUrl}`);
+    }
+
+    if (writtenPath !== 'data/servers/ookla.json') {
+        throw new Error(`Unexpected Ookla cache path: ${writtenPath}`);
+    }
+
+    const expected = JSON.stringify({'123': 'Example Ookla (27km)'}, null, 4);
+
+    if (writtenContent !== expected) {
+        throw new Error(`Expected ${expected}, got ${writtenContent}`);
+    }
+});
+
+Deno.test('loadLibreServers fetches and writes the expected cache file', async () => {
+    let requestedUrl;
+    let writtenPath;
+    let writtenContent;
+
+    await loadLibreServers({
+        fetchFn: async (url) => {
+            requestedUrl = url;
+
+            return {
+                ok: true,
+                json: async () => [
+                    {id: '456', name: 'Example Libre'}
+                ]
+            };
+        },
+        fsModule: {
+            existsSync: () => false,
+            writeFileSync: (filePath, content) => {
+                writtenPath = filePath;
+                writtenContent = content;
+            }
+        }
+    });
+
+    if (requestedUrl !== 'https://librespeed.org/backend-servers/servers.php') {
+        throw new Error(`Unexpected LibreSpeed URL: ${requestedUrl}`);
+    }
+
+    if (writtenPath !== 'data/servers/librespeed.json') {
+        throw new Error(`Unexpected LibreSpeed cache path: ${writtenPath}`);
+    }
+
+    const expected = JSON.stringify({'456': 'Example Libre'}, null, 4);
+
+    if (writtenContent !== expected) {
+        throw new Error(`Expected ${expected}, got ${writtenContent}`);
+    }
+});
+
+Deno.test('loadOoklaServers throws a provider-specific error when the request fails', async () => {
+    const requestError = new Error('network down');
+    let thrownError;
+
+    try {
+        await loadOoklaServers({
+            fetchFn: async () => {
+                throw requestError;
+            },
+            fsModule: {
+                existsSync: () => false,
+                writeFileSync: () => {
+                    throw new Error('writeFileSync should not be called when fetch fails');
+                }
+            }
+        });
+    } catch (error) {
+        thrownError = error;
+    }
+
+    if (!thrownError) {
+        throw new Error('Expected loadOoklaServers to throw');
+    }
+
+    if (thrownError.message !== 'Could not load Ookla servers: network down') {
+        throw new Error(`Unexpected error message: ${thrownError.message}`);
+    }
+
+    if (thrownError.cause !== requestError) {
+        throw new Error('Expected the original request error to be preserved as cause');
+    }
+});
+
+Deno.test('loadLibreServers throws a provider-specific error when the response is not ok', async () => {
+    let thrownError;
+
+    try {
+        await loadLibreServers({
+            fetchFn: async () => ({
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable'
+            }),
+            fsModule: {
+                existsSync: () => false,
+                writeFileSync: () => {
+                    throw new Error('writeFileSync should not be called when the response is not ok');
+                }
+            }
+        });
+    } catch (error) {
+        thrownError = error;
+    }
+
+    if (!thrownError) {
+        throw new Error('Expected loadLibreServers to throw');
+    }
+
+    if (thrownError.message !== 'Could not load LibreSpeed servers: Request failed with status 503 Service Unavailable') {
+        throw new Error(`Unexpected error message: ${thrownError.message}`);
+    }
+
+    if (!(thrownError.cause instanceof Error) || thrownError.cause.message !== 'Request failed with status 503 Service Unavailable') {
+        throw new Error('Expected the response failure to be preserved as the error cause');
+    }
+});


### PR DESCRIPTION
## Summary
- restore macOS startup support by mapping the Ookla bootstrap to the official universal archive for both Intel and Apple Silicon Macs
- replace fire-and-forget server list prefetching with explicit awaited startup loaders and switch the LibreSpeed bootstrap request path to `fetch`, which works reliably in Deno on macOS
- document macOS source-based startup in the README files and make the dev-mode page use local logo assets instead of an external Imgur dependency

## Problem
MySpeed could not complete startup on macOS. The Ookla bootstrap metadata only covered `darwin/x64` with a stale archive name and had no `darwin/arm64` entry, so Apple Silicon startup failed before the CLI could load. After fixing that, startup still surfaced an unhandled `AggregateError` because server list prefetching ran as top-level fire-and-forget requests in `loadServers.js`. In this environment the LibreSpeed bootstrap endpoint was reachable via native `fetch`, but the previous Axios-based request path timed out, which prevented the application from reaching a listening state.

The dev-mode fallback page also depended on an external Imgur image for the logo and favicon. When that asset returned rate-limit responses, the page rendered with broken images during local development.

## Fix
This change updates the macOS Ookla binary mapping so both `darwin/x64` and `darwin/arm64` use Ookla's official `macosx-universal.tgz` archive. It also adds a regression test to lock that behavior in.

Server bootstrap loading is now explicit startup work instead of module-level side effects. `loadServers.js` exports awaited loader functions for Ookla and LibreSpeed, preserves the existing cache file formats, surfaces provider-specific failures with clearer errors, and uses `fetch` by default instead of Axios for bootstrap requests. `server/index.js` now awaits server prefetch before continuing startup and routes startup failures through the existing `errorHandler`, which avoids unhandled promise rejections and makes failures actionable.

To improve the local development experience, the dev-mode template now uses local logo assets served from `client/public` rather than relying on an external Imgur URL, and the README files now mention macOS source-based startup support.

## Validation
- `deno test server/config/binaries.test.js`
- `deno test server/util/loadServers.test.js`
- `deno test --allow-read server/templates/env.test.js`
- `deno eval "import { load as loadCli } from './server/util/loadCli.js'; await loadCli(); console.log('CLI providers loaded')"`
- `timeout 25s deno run --allow-all server/index.js`
