### PR TITLE
📊 Server name metrics

### DIFF
--- a/client/src/common/components/ProviderDialog/ProviderDialog.jsx
+++ b/client/src/common/components/ProviderDialog/ProviderDialog.jsx
@@ -79,6 +79,19 @@ export const ProviderDialog = ({open, onClose}) => {
     const isUsingCustomUrl = provider === "libre" && libreUrl && libreUrl !== "none";
     const canUpdate = provider !== "ookla" || acceptedOokla;
 
+    const formatServerLabel = (entry) => {
+        if (!entry) return "";
+        if (typeof entry === "string") return entry;
+        const location = [entry.name, entry.country].filter(Boolean).join(", ");
+        const head = entry.sponsor || location || entry.host || "";
+        const parts = [];
+        if (head) parts.push(head);
+        if (entry.sponsor && location) parts.push(location);
+        const main = parts.join(" - ");
+        const distance = (entry.distance || entry.distance === 0) ? ` (${entry.distance} km)` : "";
+        return main + distance;
+    };
+
     return (
         <Dialog open={open} onClose={onClose} className="provider-dialog-wrapper">
             {({close}) => (
@@ -120,10 +133,10 @@ export const ProviderDialog = ({open, onClose}) => {
                                                 onChange={(e) => handleServerIdChange(e.target.value)}>
                                             <option value="none">{t("dialog.provider.choose_automatically")}</option>
                                             {provider === "ookla" && Object.keys(ooklaServers).map((current, index) => (
-                                                <option key={index} value={current}>{ooklaServers[current]}</option>
+                                                <option key={index} value={current}>{formatServerLabel(ooklaServers[current])}</option>
                                             ))}
                                             {provider === "libre" && Object.keys(libreServers).map((current, index) => (
-                                                <option key={index} value={current}>{libreServers[current]}</option>
+                                                <option key={index} value={current}>{formatServerLabel(libreServers[current])}</option>
                                             ))}
                                         </select>
                                     </div>

--- a/server/controller/speedtests.js
+++ b/server/controller/speedtests.js
@@ -5,8 +5,8 @@ import { getValue } from './config.js';
 
 const DEFAULT_RETENTION_DAYS = 365;
 
-export const create = async (ping, download, upload, time, serverId, type = "auto", resultId = null, error = null, jitter = null) => {
-    return (await tests.create({ping, jitter, download, upload, error, serverId, type, resultId, time, created: new Date().toISOString()})).id;
+export const create = async (ping, download, upload, time, serverId, type = "auto", resultId = null, error = null, jitter = null, serverName = null, serverHost = null) => {
+    return (await tests.create({ping, jitter, download, upload, error, serverId, serverName, serverHost, type, resultId, time, created: new Date().toISOString()})).id;
 }
 
 export const getOne = async (id) => {

--- a/server/migrations/0003-add-server-name-host-columns.js
+++ b/server/migrations/0003-add-server-name-host-columns.js
@@ -1,0 +1,21 @@
+import { DataTypes } from 'sequelize';
+
+export async function up(queryInterface) {
+    const tableDescription = await queryInterface.describeTable('speedtests');
+
+    if (!tableDescription.serverName) {
+        await queryInterface.addColumn('speedtests', 'serverName', {
+            type: DataTypes.STRING,
+            allowNull: true,
+            defaultValue: null
+        });
+    }
+
+    if (!tableDescription.serverHost) {
+        await queryInterface.addColumn('speedtests', 'serverHost', {
+            type: DataTypes.STRING,
+            allowNull: true,
+            defaultValue: null
+        });
+    }
+}

--- a/server/models/Speedtests.js
+++ b/server/models/Speedtests.js
@@ -11,6 +11,16 @@ export default db.define("speedtests", {
         type: Sequelize.INTEGER,
         defaultValue: 0
     },
+    serverName: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: null
+    },
+    serverHost: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        defaultValue: null
+    },
     ping: {
         type: Sequelize.INTEGER,
         allowNull: false

--- a/server/routes/prometheus.js
+++ b/server/routes/prometheus.js
@@ -2,16 +2,41 @@ import express from 'express';
 import * as testController from '../controller/speedtests.js';
 import promClient from 'prom-client';
 import * as config from '../controller/config.js';
+import * as serverController from '../controller/servers.js';
 import bcrypt from 'bcryptjs';
 
 const app = express.Router();
 
-const pingGauge = new promClient.Gauge({name: 'myspeed_ping', help: 'Current ping in ms'});
-const jitterGauge = new promClient.Gauge({name: 'myspeed_jitter', help: 'Current jitter in ms'});
-const downloadGauge = new promClient.Gauge({name: 'myspeed_download', help: 'Current download speed in Mbps'});
-const uploadGauge = new promClient.Gauge({name: 'myspeed_upload', help: 'Current upload speed in Mbps'});
-const currentServerGauge = new promClient.Gauge({name: 'myspeed_server', help: 'Current server ID',});
-const timeGauge = new promClient.Gauge({name: 'myspeed_time', help: 'Time of the test'});
+const speedLabels = ['server_id', 'server_name', 'server_host'];
+
+const pingGauge = new promClient.Gauge({name: 'myspeed_ping', help: 'Current ping in ms', labelNames: speedLabels});
+const jitterGauge = new promClient.Gauge({name: 'myspeed_jitter', help: 'Current jitter in ms', labelNames: speedLabels});
+const downloadGauge = new promClient.Gauge({name: 'myspeed_download', help: 'Current download speed in Mbps', labelNames: speedLabels});
+const uploadGauge = new promClient.Gauge({name: 'myspeed_upload', help: 'Current upload speed in Mbps', labelNames: speedLabels});
+const currentServerGauge = new promClient.Gauge({name: 'myspeed_server', help: 'Current server ID'});
+const timeGauge = new promClient.Gauge({name: 'myspeed_time', help: 'Time of the test', labelNames: speedLabels});
+const serverInfoGauge = new promClient.Gauge({
+    name: 'myspeed_server_info',
+    help: 'Static info about the speedtest server (always 1). Join via group_left to add server metadata to other metrics.',
+    labelNames: speedLabels
+});
+
+const resolveServerLabels = (latest) => {
+    const serverId = latest.serverId ?? 0;
+    let serverName = latest.serverName ?? null;
+    let serverHost = latest.serverHost ?? null;
+
+    if (!serverName) {
+        const ooklaServers = serverController.getOoklaServers();
+        if (ooklaServers && ooklaServers[serverId]) serverName = ooklaServers[serverId];
+    }
+
+    return {
+        server_id: String(serverId),
+        server_name: serverName ?? '',
+        server_host: serverHost ?? ''
+    };
+};
 
 app.get('/metrics', async (req, res) => {
     let passwordHash = await config.getValue("password");
@@ -38,15 +63,25 @@ app.get('/metrics', async (req, res) => {
     if (latest.error || latest.ping === -1)
         return res.status(500).end('Error in the latest test');
 
-    pingGauge.set(latest.ping);
+    const labels = resolveServerLabels(latest);
+
+    pingGauge.reset();
+    jitterGauge.reset();
+    downloadGauge.reset();
+    uploadGauge.reset();
+    timeGauge.reset();
+    serverInfoGauge.reset();
+
+    pingGauge.set(labels, latest.ping);
     if (latest.jitter !== null && latest.jitter !== undefined)
-        jitterGauge.set(latest.jitter);
-    downloadGauge.set(latest.download);
-    uploadGauge.set(latest.upload);
+        jitterGauge.set(labels, latest.jitter);
+    downloadGauge.set(labels, latest.download);
+    uploadGauge.set(labels, latest.upload);
     currentServerGauge.set(latest.serverId);
+    serverInfoGauge.set(labels, 1);
 
     if (latest.time)
-        timeGauge.set(latest.time);
+        timeGauge.set(labels, latest.time);
 
     res.set('Content-Type', promClient.register.contentType);
     res.end(await promClient.register.metrics());

--- a/server/routes/prometheus.js
+++ b/server/routes/prometheus.js
@@ -26,9 +26,17 @@ const resolveServerLabels = (latest) => {
     let serverName = latest.serverName ?? null;
     let serverHost = latest.serverHost ?? null;
 
-    if (!serverName) {
+    if (!serverName || !serverHost) {
         const ooklaServers = serverController.getOoklaServers();
-        if (ooklaServers && ooklaServers[serverId]) serverName = ooklaServers[serverId];
+        const entry = ooklaServers && ooklaServers[serverId];
+        if (entry) {
+            if (typeof entry === "string") {
+                if (!serverName) serverName = entry;
+            } else if (typeof entry === "object") {
+                if (!serverName) serverName = entry.sponsor || entry.name || null;
+                if (!serverHost) serverHost = entry.host || null;
+            }
+        }
     }
 
     return {

--- a/server/tasks/speedtest.js
+++ b/server/tasks/speedtest.js
@@ -94,10 +94,10 @@ export const create = async (type = "auto", retried = false) => {
             test = await run(retried);
         }
 
-        let {ping, jitter, download, upload, time, resultId} = await parseData.parseData(process.env.PREVIEW_MODE === "true" ?
+        let {ping, jitter, download, upload, time, resultId, serverName, serverHost} = await parseData.parseData(process.env.PREVIEW_MODE === "true" ?
             "ookla" : mode, test);
 
-        let testResult = await tests.create(ping, download, upload, time, test.serverId, type, resultId, null, jitter);
+        let testResult = await tests.create(ping, download, upload, time, test.serverId, type, resultId, null, jitter, serverName, serverHost);
         console.log(`Test #${testResult} was executed successfully in ${time}s. 🏓 ${ping} (±${jitter || 'N/A'}) ⬇ ${download}️ ⬆ ${upload}️`);
         createRecommendations().then(() => "");
         setRunning(false);

--- a/server/util/loadServers.js
+++ b/server/util/loadServers.js
@@ -5,17 +5,37 @@ const sources = [
     {
         file: "data/servers/ookla.json",
         url: "https://www.speedtest.net/api/js/servers?limit=20",
-        format: (row) => `${row.name} (${row.distance}km)`
+        format: (row) => ({
+            name: row.name,
+            sponsor: row.sponsor,
+            country: row.country,
+            cc: row.cc,
+            distance: row.distance,
+            host: row.host
+        }),
+        isCurrent: (entries) => entries.length === 0 || entries.every(([, value]) =>
+            value !== null && typeof value === "object" && "sponsor" in value && "name" in value)
     },
     {
         file: "data/servers/librespeed.json",
         url: "https://librespeed.org/backend-servers/servers.php",
-        format: (row) => row.name
+        format: (row) => row.name,
+        isCurrent: () => true
     }
 ];
 
-for (const {file, url, format} of sources) {
-    if (fs.existsSync(file)) continue;
+const isFileCurrent = (file, isCurrent) => {
+    try {
+        const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+        if (parsed === null || typeof parsed !== "object") return false;
+        return isCurrent(Object.entries(parsed));
+    } catch {
+        return false;
+    }
+};
+
+for (const {file, url, format, isCurrent} of sources) {
+    if (fs.existsSync(file) && isFileCurrent(file, isCurrent)) continue;
 
     getJson(url)
         .then((data) => {

--- a/server/util/providers/parseData.js
+++ b/server/util/providers/parseData.js
@@ -17,13 +17,16 @@ export const parseOokla = (test) => {
     let download = roundSpeed(test.download.bandwidth);
     let upload = roundSpeed(test.upload.bandwidth);
     let time = Math.round((test.download.elapsed + test.upload.elapsed) / 1000);
+    let serverName = test.server?.name ?? null;
+    let serverHost = test.server?.host ?? null;
 
-    return {ping, jitter, download, upload, time, resultId: test.result?.id};
+    return {ping, jitter, download, upload, time, resultId: test.result?.id, serverName, serverHost};
 };
 
-export const parseLibre = (test) => ({...test, ping: Math.round(test.ping), 
+export const parseLibre = (test) => ({...test, ping: Math.round(test.ping),
     jitter: test.jitter ? parseFloat(parseFloat(test.jitter).toFixed(2)) : null,
-    time: Math.round(test.elapsed / 1000), resultId: null});
+    time: Math.round(test.elapsed / 1000), resultId: null,
+    serverName: test.server?.name ?? null, serverHost: test.server?.url ?? null});
 
 export const parseCloudflare = (test) => {
     if (test && test.latency_measurement && test.speed_measurements) {
@@ -42,10 +45,12 @@ export const parseCloudflare = (test) => {
         const time = Math.round((test.elapsed || 30000) / 1000);
         
         return {ping, jitter, download: parseFloat(download.toFixed(2)),
-            upload: parseFloat(upload.toFixed(2)), time, resultId: null};
+            upload: parseFloat(upload.toFixed(2)), time, resultId: null,
+            serverName: null, serverHost: null};
     }
 
-    return {ping: 0, jitter: null, download: 0, upload: 0, time: 0, resultId: null};
+    return {ping: 0, jitter: null, download: 0, upload: 0, time: 0, resultId: null,
+        serverName: null, serverHost: null};
 };
 
 export const parseData = (provider, data) => {


### PR DESCRIPTION
## 📊 Server name metrics

This PR adds new fields to the prometheus endpoint. It allows you to see what the speedtest server was that the test has been made with. 

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Fixes #732