### PR TITLE
🛢️ InfluxDB Integration

### DIFF
--- a/client/public/assets/locales/de.json
+++ b/client/public/assets/locales/de.json
@@ -397,6 +397,22 @@
         "interval_placeholder": "1"
       }
     },
+    "influxdb": {
+      "title": "InfluxDB",
+      "fields": {
+        "url": "Server-URL",
+        "url_placeholder": "http://localhost:8086",
+        "org": "Organisation",
+        "bucket": "Bucket",
+        "token": "API-Token",
+        "measurement": "Measurement-Name",
+        "measurement_placeholder": "speedtests (Standard)",
+        "host": "Host-Tag",
+        "host_placeholder": "Standard: Hostname des Geräts",
+        "tags": "Zusätzliche Tags",
+        "tags_placeholder": "region=eu,role=primary (komma-getrennt)"
+      }
+    },
     "ntfy": {
       "title": "ntfy",
       "fields": {

--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -465,6 +465,22 @@
         "interval_placeholder": "1"
       }
     },
+    "influxdb": {
+      "title": "InfluxDB",
+      "fields": {
+        "url": "Server-URL",
+        "url_placeholder": "http://localhost:8086",
+        "org": "Organization",
+        "bucket": "Bucket",
+        "token": "API token",
+        "measurement": "Measurement name",
+        "measurement_placeholder": "speedtests (default)",
+        "host": "Host tag",
+        "host_placeholder": "Defaults to the machine hostname",
+        "tags": "Additional tags",
+        "tags_placeholder": "region=eu,role=primary (comma-separated)"
+      }
+    },
     "ntfy": {
       "title": "ntfy",
       "fields": {

--- a/server/integrations/influxdb.js
+++ b/server/integrations/influxdb.js
@@ -1,0 +1,68 @@
+import os from "os";
+import { postText } from "../util/http.js";
+
+const escapeTag = (value) => String(value).replace(/[ ,=]/g, "\\$&");
+
+const buildLine = (measurement, tags, fields, timestampSeconds) => {
+    const tagPart = Object.entries(tags)
+        .filter(([, v]) => v !== undefined && v !== null && v !== "")
+        .map(([k, v]) => `${escapeTag(k)}=${escapeTag(v)}`)
+        .join(",");
+
+    const fieldPart = Object.entries(fields)
+        .filter(([, v]) => typeof v === "number" && Number.isFinite(v))
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+
+    const prefix = tagPart ? `${measurement},${tagPart}` : measurement;
+    return `${prefix} ${fieldPart} ${timestampSeconds}`;
+};
+
+const send = (c, line, activity) => {
+    const baseUrl = c.url.replace(/\/+$/, "");
+    const url = `${baseUrl}/api/v2/write?org=${encodeURIComponent(c.org)}` +
+        `&bucket=${encodeURIComponent(c.bucket)}&precision=s`;
+    return postText(url, line, {
+        headers: {
+            "Authorization": `Token ${c.token}`,
+            "Content-Type": "text/plain; charset=utf-8"
+        },
+        activity
+    });
+};
+
+export default (registerEvent) => {
+    registerEvent("testFinished", async ({data: c}, data, activity) => {
+        const tags = {
+            host: c.host || os.hostname(),
+            ...(c.tags ? Object.fromEntries(c.tags.split(",")
+                .map(t => t.split("=").map(s => s.trim()))
+                .filter(([k, v]) => k && v)) : {})
+        };
+
+        const fields = {
+            download: data.download,
+            upload: data.upload,
+            ping: data.ping,
+            jitter: data.jitter ?? 0
+        };
+
+        const timestamp = Math.floor(Date.now() / 1000);
+        const line = buildLine(c.measurement || "speedtests", tags, fields, timestamp);
+
+        await send(c, line, activity);
+    });
+
+    return {
+        icon: "fa-solid fa-database",
+        fields: [
+            {name: "url", type: "text", required: true, regex: /^https?:\/\/.+/},
+            {name: "org", type: "text", required: true},
+            {name: "bucket", type: "text", required: true},
+            {name: "token", type: "text", required: true},
+            {name: "measurement", type: "text", required: false},
+            {name: "host", type: "text", required: false},
+            {name: "tags", type: "text", required: false}
+        ]
+    };
+};


### PR DESCRIPTION
## 🛢️ InfluxDB Integration

Adds support for the InfluxDB provider. It sends your finished speedtests directly to your instance.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues <!-- If there are any related issues, please link them here. -->

Closes #1087