### PR TITLE
UI/UX: Non-localized "N/A" fallback in relative time display

### DIFF
--- a/client/src/pages/Home/components/LatestTest/utils.js
+++ b/client/src/pages/Home/components/LatestTest/utils.js
@@ -16,5 +16,6 @@ export function generateRelativeTime(created) {
         return Math.floor(diff / 3600) === 1 ? t("time.hour") : t("time.hours", {replace: {hours: Math.floor(diff / 3600)}});
     }
 
-    return "N/A"
+    const days = Math.floor(diff / 86400);
+    return days === 1 ? t("time.day") : t("time.days", {replace: {days: days}});
 }


### PR DESCRIPTION
## 🎨 UI/UX Improvement

### Problem
The generateRelativeTime function uses i18n for all time strings but returns a hardcoded English "N/A" for tests older than 24 hours. Non-English users will see an untranslated fallback string in an otherwise fully localized interface. Additionally, "N/A" is a poor UX choice — it hides information (the test exists and has a real timestamp) with no explanation, leaving users uncertain whether something broke or the data is simply old.


**Severity**: `medium`
**File**: `client/src/pages/Home/components/LatestTest/utils.js`

### Solution
Replace the hardcoded fallback with a localized string that conveys useful information:


### Changes
- `client/src/pages/Home/components/LatestTest/utils.js` (modified)

## 📋 Description

Please include a summary of the changes and the related issue. Explain the problem that you are solving and provide the
necessary context.

## 🚀 Changes made to ...

- [ ] 🔧 Server
- [ ] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues 

Fixes #(issue)

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1566