### PR TITLE
fix: Detect interfaces without external connectivity probe

### DIFF
--- a/server/util/loadInterfaces.js
+++ b/server/util/loadInterfaces.js
@@ -1,5 +1,4 @@
 import os from 'node:os';
-import https from 'node:https';
 import * as config from '../controller/config.js';
 
 export let interfaces = {};
@@ -15,40 +14,14 @@ export const requestInterfaces = async () => {
 
             if (address.internal) continue;
 
-            let options = {hostname: "speed.cloudflare.com", path: "/__down?bytes=1", method: "GET",
-                family: address.family === "IPv4" ? 4 : 6, timeout: 5000};
-
-            options.agent = new https.Agent(options);
-            options.localAddress = address.address;
-
-            await new Promise((resolve) => {
-
-                const req = https.request(options, () => {
-                    if (!interfacesResult[i]) interfacesResult[i] = [];
-                    interfacesResult[i].push(address.address);
-                    req.destroy();
-                    resolve();
-                });
-
-                req.on('error', () => resolve());
-                req.on('timeout', () => req.destroy());
-
-                req.end();
-            });
+            if (!interfacesResult[i]) interfacesResult[i] = [];
+            interfacesResult[i].push(address.address);
         }
-
-        if (!interfacesResult[i]) delete interfacesResult[i];
     }
 
+    interfaces = {};
     for (let i in interfacesResult) {
-        for (let j in interfacesResult[i]) {
-            if (interfacesResult[i][j].includes(".")) {
-                interfaces[i] = interfacesResult[i][j];
-                break;
-            }
-        }
-
-        if (!interfaces[i]) interfaces[i] = interfacesResult[i][0];
+        interfaces[i] = interfacesResult[i].find((address) => address.includes(".")) || interfacesResult[i][0];
     }
 
     for (let i in interfaces) {
@@ -57,12 +30,13 @@ export const requestInterfaces = async () => {
 
     const currentInterface = await config.getValue("interface");
 
-    if (!interfaces[currentInterface]) {
-        if (!currentInterface) {
-            console.warn("No interface set. Falling back to default.");
-        } else {
-            console.warn(`Interface ${currentInterface} not found. Falling back to default.`);
-        }
-        await config.updateValue("interface", Object.keys(interfaces)[0]);
+    if (currentInterface && interfaces[currentInterface]) return;
+
+    if (!currentInterface) {
+        console.warn("No interface set. Falling back to default.");
+    } else {
+        console.warn(`Interface ${currentInterface} not found. Falling back to default.`);
     }
+
+    await config.updateValue("interface", Object.keys(interfaces)[0] || "none");
 };


### PR DESCRIPTION
## Summary

- Interface detection previously bound an HTTPS request to `speed.cloudflare.com` per interface and only listed an interface if that probe succeeded.
- In many valid Docker network setups (custom bridge networks, ipvlan, restrictive DNS), that probe fails even though the interface itself is perfectly usable — so the real interface (e.g. `eth0`, `eno1`, `enp1s0`) gets reported as "not found" and the saved config silently overwritten.
- Since `requestInterfaces()` reruns every hour, a transient probe failure could keep resetting the user's chosen interface indefinitely.
- This removes the connectivity probe and lists interfaces directly from `os.networkInterfaces()`, only falling back/resetting the config when the interface has genuinely disappeared from that list.

Fixes #806

## Test plan

- [x] Verified locally that `os.networkInterfaces()`-based detection lists all non-internal interfaces immediately on startup (`Found interface ... with IP ...`)
- [x] Deployed to a remote Docker host and confirmed the interface (`eth0` inside the container) is detected and saved on first boot, and persists correctly across a container restart with no fallback warning
- [x] Confirmed the previous implementation's `https.Agent`/`localAddress` connectivity probe is what caused interfaces to be dropped in environments without a working Cloudflare route (matches multiple reports on #806, including custom bridge/ipvlan networks and DNS failures)