### PR TITLE
Add optional topic_id field for Telegram message sending

### DIFF
--- a/client/public/assets/locales/bg.json
+++ b/client/public/assets/locales/bg.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Токен на бот",
         "chat_id": "Идентификатор на чата",
+        "topic_id": "ID на темата (незадължително)",
         "error_message": "Съобщение за грешка",
         "error_message_placeholder": "Грешка: %error%",
         "send_failed": "Изпращане на съобщения за грешки",

--- a/client/public/assets/locales/da.json
+++ b/client/public/assets/locales/da.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Bot-token",
         "chat_id": "Chat-ID",
+        "topic_id": "Emne-ID (valgfrit)",
         "error_message": "Fejlmeddelelse",
         "error_message_placeholder": "Fejl: %error%",
         "send_failed": "Send fejlmeddelelser",

--- a/client/public/assets/locales/de.json
+++ b/client/public/assets/locales/de.json
@@ -445,6 +445,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "Chat ID",
+        "topic_id": "Themen-ID (optional)",
         "error_message": "Fehlernachricht",
         "error_message_placeholder": "Fehler: %error%",
         "send_failed": "Fehlernachrichten senden",

--- a/client/public/assets/locales/en.json
+++ b/client/public/assets/locales/en.json
@@ -513,6 +513,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "Chat ID",
+        "topic_id": "Topic ID (optional)",
         "error_message": "Error message",
         "error_message_placeholder": "[%year%-%month%-%day% %hour%:%minute%] Error: %error%",
         "send_failed": "Send error messages",

--- a/client/public/assets/locales/es.json
+++ b/client/public/assets/locales/es.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "Chat ID",
+        "topic_id": "ID de tema (opcional)",
         "error_message": "Mensaje de error",
         "error_message_placeholder": "Error: %error%",
         "send_failed": "Enviar mensajes de error",

--- a/client/public/assets/locales/fr.json
+++ b/client/public/assets/locales/fr.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Token du bot",
         "chat_id": "ID de conversation",
+        "topic_id": "ID du sujet (facultatif)",
         "error_message": "Message d'erreur",
         "error_message_placeholder": "Erreur : %error%",
         "send_failed": "Envoyer des messages d'erreur",

--- a/client/public/assets/locales/id.json
+++ b/client/public/assets/locales/id.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Token Bot",
         "chat_id": "ID Chat",
+        "topic_id": "ID Topik (opsional)",
         "error_message": "Pesan kesalahan",
         "error_message_placeholder": "Kesalahan: %error%",
         "send_failed": "Kirim pesan kesalahan",

--- a/client/public/assets/locales/it.json
+++ b/client/public/assets/locales/it.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "ID chat",
+        "topic_id": "ID argomento (opzionale)",
         "error_message": "Messaggio di errore",
         "error_message_placeholder": "Errore: %error%",
         "send_failed": "Inviare messaggi di errore",

--- a/client/public/assets/locales/nl.json
+++ b/client/public/assets/locales/nl.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "Chat-ID",
+        "topic_id": "Onderwerp-ID (optioneel)",
         "error_message": "Foutmelding",
         "error_message_placeholder": "Fout: %error%",
         "send_failed": "Foutberichten verzenden",

--- a/client/public/assets/locales/pl.json
+++ b/client/public/assets/locales/pl.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Token bota",
         "chat_id": "ID czatu",
+        "topic_id": "ID wątku (opcjonalne)",
         "error_message": "Komunikat o błędzie",
         "error_message_placeholder": "Błąd: %error%",
         "send_failed": "Wysyłaj komunikaty o błędach",

--- a/client/public/assets/locales/pt.json
+++ b/client/public/assets/locales/pt.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Token de bot",
         "chat_id": "ID do bate-papo",
+        "topic_id": "ID do tópico (opcional)",
         "error_message": "Mensagem de erro",
         "error_message_placeholder": "Erro: %error%",
         "send_failed": "Enviar mensagens de erro",

--- a/client/public/assets/locales/ru.json
+++ b/client/public/assets/locales/ru.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Токен бота",
         "chat_id": "Идентификатор чата",
+        "topic_id": "ID темы (необязательно)",
         "error_message": "Сообщение об ошибке",
         "error_message_placeholder": "Ошибка: %error%",
         "send_failed": "Отправка сообщений об ошибках",

--- a/client/public/assets/locales/tr.json
+++ b/client/public/assets/locales/tr.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "Bot Token",
         "chat_id": "Sohbet Kimliği",
+        "topic_id": "Konu Kimliği (opsiyonel)",
         "error_message": "Hata mesajı",
         "error_message_placeholder": "Hata: %error%",
         "send_failed": "Hata mesajlarını gönder",

--- a/client/public/assets/locales/zh.json
+++ b/client/public/assets/locales/zh.json
@@ -393,6 +393,7 @@
       "fields": {
         "token": "机器人令牌",
         "chat_id": "聊天ID",
+        "topic_id": "话题ID（可选）",
         "error_message": "测试失败通知内容",
         "error_message_placeholder": "错误: %error%",
         "send_failed": "发送测试失败通知",

--- a/server/integrations/telegram.js
+++ b/server/integrations/telegram.js
@@ -6,19 +6,19 @@ const defaults = {
     failed: "❌ *A speedtest has failed*\n`Reason`: %error%"
 };
 
-const send = (token, chat_id, text, activity) =>
+const send = (token, chat_id, text, activity, topic_id) =>
     postJson(`https://api.telegram.org/bot${token}/sendMessage`,
-        {text, chat_id, parse_mode: "markdown"}, {activity});
+        {text, chat_id, parse_mode: "markdown", ...(topic_id ? {message_thread_id: topic_id} : {})}, {activity});
 
 export default (registerEvent) => {
     registerEvent('testFinished', async ({data: c}, data, activity) => {
         if (c.send_finished) await send(c.token, c.chat_id,
-            replaceVariables(c.finished_message || defaults.finished, data), activity);
+            replaceVariables(c.finished_message || defaults.finished, data), activity, c.topic_id);
     });
 
     registerEvent('testFailed', async ({data: c}, error, activity) => {
         if (c.send_failed) await send(c.token, c.chat_id,
-            replaceVariables(c.failed_message || defaults.failed, {error}), activity);
+            replaceVariables(c.failed_message || defaults.failed, {error}), activity, c.topic_id);
     });
 
     return {
@@ -26,6 +26,7 @@ export default (registerEvent) => {
         fields: [
             {name: "token", type: "text", required: true, regex: /(\d+):[a-zA-Z0-9_-]+/},
             {name: "chat_id", type: "text", required: true, regex: /\d+/},
+            {name: "topic_id", type: "text", required: false, regex: /^\d+$/},
             {name: "send_finished", type: "boolean", required: false},
             {name: "finished_message", type: "textarea", required: false},
             {name: "send_failed", type: "boolean", required: false},


### PR DESCRIPTION
## 📋 Description

Adds an optional `topic_id` field to the Telegram integration so messages can be sent to a specific topic/thread within a Telegram group that has Topics enabled. Without this, all messages land in the group's "General" topic regardless of configuration, which is limiting for groups organized into multiple topics.

The `topic_id` is passed through to Telegram's `sendMessage` API as `message_thread_id` only when provided, so existing integrations without a topic configured are unaffected.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [x] 🖥️ Client
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

**Server**: `server/integrations/telegram.js` — added optional `topic_id` field (validated with `/^\d+$/`) and threaded it through `send()` into the Telegram API payload as `message_thread_id`.

**Client**: Added the `topic_id` field label/description to all 14 locale files (`en`, `de`, `bg`, `da`, `es`, `fr`, `id`, `it`, `nl`, `pl`, `pt`, `ru`, `tr`, `zh`).

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have looked for similar pull requests in the repository and found none

## 🔗 Related Issues

None — this is a new feature, not tied to an existing issue.