### PR TITLE
fix: accept the mixed-case keys Pushover issues

### DIFF
--- a/server/integrations/pushover.js
+++ b/server/integrations/pushover.js
@@ -25,8 +25,8 @@ export default (registerEvent) => {
     return {
         icon: "fa-solid fa-pushover",
         fields: [
-            {name: "token", type: "text", required: true, regex: /^[a-z0-9]{30}$/},
-            {name: "user_key", type: "text", required: true, regex: /^[a-z0-9]{30}$/},
+            {name: "token", type: "text", required: true, regex: /^[A-Za-z0-9]{30}$/},
+            {name: "user_key", type: "text", required: true, regex: /^[A-Za-z0-9]{30}$/},
             {name: "send_finished", type: "boolean", required: false},
             {name: "finished_message", type: "textarea", required: false},
             {name: "send_failed", type: "boolean", required: false},


### PR DESCRIPTION
## 📋 Description

Pushover application tokens and user keys are 30 characters from a **case-sensitive** alphanumeric alphabet, but both fields are validated against `/^[a-z0-9]{30}$/`.

A key containing a single capital — which is most of them — cannot be saved at all: the field stays outlined in red and the integration can never be created.

The workaround reporters arrived at in #726 is to lowercase their own key. That is a different key naming a different account, so the integration then saves and silently delivers nothing, which is arguably worse than the original refusal.

Both fields move together, as they share the same alphabet — your own comment on the issue noted that the two patterns were already identical.

Strictly widening: every value accepted before is still accepted.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 🌐 Web
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/myspeed), only `en.json` is edited here)

Checked through the same call both ends use, `new RegExp(field.regex).test(value)`: mixed-case, all-lowercase and all-uppercase keys accepted; 29 and 31 characters, hyphens and spaces still rejected — on both `token` and `user_key`.

## 🔗 Related Issues

Fixes #726

---

<sub>Disclosure: I prepared this fix with the help of an AI assistant. The diagnosis and the regex behavior were verified against the current development branch before opening this PR.</sub>
