### PR TITLE
fix: accept the Discord webhook URLs Discord issues, and anchor the pattern

### DIFF
--- a/server/integrations/discord.js
+++ b/server/integrations/discord.js
@@ -26,7 +26,8 @@ export default (registerEvent) => {
     return {
         icon: "fa-brands fa-discord",
         fields: [
-            {name: "url", type: "text", required: true, regex: /https:\/\/.*discord.com\/api\/webhooks\/\d+\/.+/},
+            {name: "url", type: "text", required: true,
+                regex: /^https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api(?:\/v\d+)?\/webhooks\/\d+\/[\w-]+(?:\?\S*)?$/},
             {name: "display_name", type: "text", required: false},
             {name: "send_finished", type: "boolean", required: false},
             {name: "finished_message", type: "textarea", required: false},


### PR DESCRIPTION
## 📋 Description

Three separate problems with `/https:\/\/.*discord.com\/api\/webhooks\/\d+\/.+/`:

**1. `discordapp.com` is rejected.** That host is still served and still handed out. The unescaped dot does not rescue it — `discord` + any single character + `com` does not match `discordapp.com`. This is what #1297 is about, and why the reported workaround is deleting "app" from one's own webhook URL.

**2. The pattern is unanchored.** Both ends check it with `RegExp.test`, which matches anywhere in the string, so any URL that merely *contains* a webhook-shaped substring is accepted — and the stored value is where speedtest results are then posted:

```js
const old = /https:\/\/.*discord.com\/api\/webhooks\/\d+\/.+/;
old.test("https://evil.example/collect?next=https://discord.com/api/webhooks/1/TOKEN")
// true
```

**3. The leading `.*` accepts any host ending in the pattern**, so `notdiscord.com` passes.

The replacement also allows two forms the old pattern rejected: the versioned `/api/v10/webhooks/...` path, and Discord's own `?thread_id=` parameter.

Stored values are not re-validated on read, so existing integrations keep working; the change only affects saving.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 🌐 Web
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [x] This pull request does not contain translations (they are managed on [Crowdin](https://crowdin.com/project/myspeed), only `en.json` is edited here)

Checked through `new RegExp(field.regex).test(value)`. Accepted: `discord.com`, `discordapp.com`, `ptb.`/`canary.` hosts, `/api/v10/`, `?thread_id=`. Rejected: `notdiscord.com`, `discord.com.evil.test`, a webhook URL embedded in a foreign URL,
plaintext `http://`, a missing token, a non-numeric id.

## 🔗 Related Issues

Refs #1297

This fixes the half of that report about the URL not saving. Several reporters also say the webhook saves and then never delivers — I have a suspicion about that (Discord documents a `User-Agent` as required and Node's `fetch` sends none) but I have not verified it, so it is deliberately left out of this PR.

---

<sub>Disclosure: I prepared this fix with the help of an AI assistant. The diagnosis and the regex behavior were verified against the current development branch before opening this PR.</sub>
