### PR TITLE
fix: allow Gotify v3 tokens in integration key validation

### DIFF
--- a/server/integrations/gotify.js
+++ b/server/integrations/gotify.js
@@ -25,7 +25,7 @@ export default (registerEvent) => {
         icon: "fa-solid fa-bell",
         fields: [
             {name: "url", type: "text", required: true, regex: /https?:\/\/.+/},
-            {name: "key", type: "text", required: true, regex: /^.{15}$/},
+            {name: "key", type: "text", required: true, regex: /^.{15,}$/},
             {name: "priority", type: "text", required: true, regex: /^[0-9]$/},
             {name: "send_finished", type: "boolean", required: false},
             {name: "finished_message", type: "textarea", required: false},


### PR DESCRIPTION

## 📋 Description

MySpeed validates Gotify application tokens with regex `/^.{15}$/` which requires exactly 15 characters. This works with Gotify v2 but **rejects Gotify v3 tokens**, which are significantly longer (prefixed with `gtfya.`, ~52 characters).

This PR changes the regex to `/^.{15,}$/` — accepts tokens of 15+ characters, compatible with both v2 and v3 formats.

## 🚀 Changes made to ...

- [x] 🔧 Server
- [ ] 🖥️ Client
- [ ] 🌐 Web
- [ ] 📚 Documentation
- [ ] 🔄 Other: ___

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] I have looked for similar pull requests in the repository and found none
- [ ] This pull request does not contain translations

## 🔗 Related Issues

Fixes a compatibility issue where Gotify v3 tokens were rejected by the key validation.
